### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Go Libraries
 
 * [graphql](https://github.com/graphql-go/graphql) - An implementation of GraphQL for Go follows graphql-js
-* [graphql-relay-go](https://github.com/graphql-go/graphql-relay-go) - A Go/Golang library to help construct a server supporting react-relay.
+* [graphql-relay-go](https://github.com/graphql-go/relay) - A Go/Golang library to help construct a server supporting react-relay.
 * [graphql](https://github.com/tmc/graphql) - GraphQL parser and server for Go.
 * [c-graphqlparser](https://github.com/tecbot/c-graphqlparser) - Go-gettable version of the libgraphqlparser C library for parsing GraphQL.
 * [tallstreet-graphql](https://github.com/tallstreet/graphql) - GraphQL parser and server for Go that leverages libgraphqlparser
@@ -121,7 +121,7 @@ If you want to contribute to this list (please do), send me a pull request.
 <a name="lib-dotnet" />
 ### .NET Libraries
 
-* [graphql-dotnet](https://github.com/joemcbride/graphql-dotnet) - GraphQL for .NET.
+* [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet) - GraphQL for .NET.
 
 <a name="lib-elixir" />
 ### Elixir Libraries
@@ -160,7 +160,7 @@ If you want to contribute to this list (please do), send me a pull request.
 <a name="example-js" />
 ### JavaScript Examples
 
-* [relay-starter-kit](https://github.com/facebook/relay-starter-kit) - Barebones starting point for a Relay application.
+* [relay-starter-kit](https://github.com/relayjs/relay-starter-kit) - Barebones starting point for a Relay application.
 * [swapi-graphql](https://github.com/graphql/swapi-graphql) - A GraphQL schema and server wrapping [swapi](http://swapi.co/).
 * [graphql-server](https://github.com/RisingStack/graphql-server) - GraphQL server with Mongoose (MongoDB) and Node.js.
 * [graphql-intro](https://github.com/clayallsopp/graphql-intro) - https://medium.com/@clayallsopp/your-first-graphql-server-3c766ab4f0a2.
@@ -184,7 +184,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Go Examples
 
 * [golang-relay-starter-kit](https://github.com/sogko/golang-relay-starter-kit) - Barebones starting point for a Relay application with Golang GraphQL server.
-* [golang-graphql-playground](https://github.com/graphql-go/golang-graphql-playground) - An example Golang GraphQL server written with graphql-go and graphql-relay-go. Try live demo at: http://bit.ly/try-graphql-go
+* [golang-graphql-playground](https://github.com/graphql-go/playground) - An example Golang GraphQL server written with graphql-go and graphql-relay-go. Try live demo at: http://bit.ly/try-graphql-go
 * [todomvc-relay-go](https://github.com/sogko/todomvc-relay-go) - Port of the React/Relay TodoMVC app, driven by a Golang GraphQL backend.
 
 <a name="example-scala" />


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### GitHub Corrected URLs 
Was | Now 
--- | --- 
https://github.com/facebook/relay-starter-kit | https://github.com/relayjs/relay-starter-kit 
https://github.com/graphql-go/golang-graphql-playground | https://github.com/graphql-go/playground 
https://github.com/graphql-go/graphql-relay-go | https://github.com/graphql-go/relay 
https://github.com/joemcbride/graphql-dotnet | https://github.com/graphql-dotnet/graphql-dotnet 
