### PR TITLE
Adding GraphQLHub under Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphQLviz](https://github.com/Macroz/GraphQLviz) - GraphQLviz marries GraphQL (schemas) with Graphviz.
 * [Relay Playground](http://facebook.github.io/relay/prototyping/playground.html)
 * [GraphQL AST Explorer](http://dferber90.github.io/graphql-ast-explorer/) - Explore the AST of a GraphQL document interactively
+* [GraphQLHub](https://www.graphqlhub.com/) - Query public API's schemas (e.g. Reddit, Twitter, Github, etc) using GraphiQL
 
 <a name="services" />
 ## Services


### PR DESCRIPTION
GraphQLHub provides schemas for public API's like: Reddit, Twitter, Github and more. Thought its a good resource for us GraphQL fans.