### PR TITLE
Add js-graphql-intellij-plugin to tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Relay Playground](http://facebook.github.io/relay/prototyping/playground.html)
 * [GraphQL AST Explorer](http://dferber90.github.io/graphql-ast-explorer/) - Explore the AST of a GraphQL document interactively
 * [GraphQLHub](https://www.graphqlhub.com/) - Query public API's schemas (e.g. Reddit, Twitter, Github, etc) using GraphiQL
+* [js-graphql-intellij-plugin](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/) - GraphQL language support for IntelliJ IDEA and WebStorm, including Relay.QL tagged templates in JavaScript and TypeScript.
 
 <a name="services" />
 ## Services


### PR DESCRIPTION
js-graphql-intellij-plugin is a useful plugin for people those using relay & graphql and development with Intellij IDEs. It brings completion, error highlighting etc. 