### PR TITLE
Add react-starter-kit example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### JavaScript Examples
 
 * [relay-starter-kit](https://github.com/relayjs/relay-starter-kit) - Barebones starting point for a Relay application.
+* [react-starter-kit](https://github.com/kriasoft/react-starter-kit) - Isomorphic web app boilerplate (Node.js/Express, GraphQL, React)
 * [swapi-graphql](https://github.com/graphql/swapi-graphql) - A GraphQL schema and server wrapping [swapi](http://swapi.co/).
 * [graphql-server](https://github.com/RisingStack/graphql-server) - GraphQL server with Mongoose (MongoDB) and Node.js.
 * [graphql-intro](https://github.com/clayallsopp/graphql-intro) - https://medium.com/@clayallsopp/your-first-graphql-server-3c766ab4f0a2


### PR DESCRIPTION
It contains a boilerplate code for building isomorphic apps with Node.js/Express, GraphQL, and React