### PR TITLE
Add link to 'Barebones Relay application with Rails GraphQL server'

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Ruby Examples
 
 * [graphql-ruby-demo](https://github.com/rmosolgo/graphql-ruby-demo) - Use graphql-ruby to expose a Rails app.
+* [relay-on-rails](https://github.com/nethsix/relay-on-rails) - Barebones starter kit for Relay application with Rails GraphQL server.
 
 <a name="example-go" />
 ### Go Examples


### PR DESCRIPTION
A barebones Relay application with Rails GraphQL server that anyone can clone, and get started.
Comes with:
* Instructions on how to install
* A rake task to update GraphQL JSON schema (required by babel-relay-plugin) when GraphQL schema on Rails change.
* A link to an article explains the details of entire setup to help learning