### PR TITLE
Replace link to obsolete repository with link to the new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-aws](https://github.com/jonsharratt/graphql-aws) - Amazon AWS GraphQL API Server.
 * [graffiti-todo](https://github.com/RisingStack/graffiti-todo) - Example Relay TodoMVC application using graffiti-mongoose.
 * [devknoll/gist:8b274f1c5d05230bfade](https://gist.github.com/devknoll/8b274f1c5d05230bfade)
-* [codefoundries/isomorphic-material-relay-starter-kit](https://github.com/codefoundries/isomorphic-material-relay-starter-kit) - Isomorphic Relay with authentication using JWT, Material-UI.
+* [UniversalRelayBoilerplate](https://github.com/codefoundries/UniversalRelayBoilerplate)
+Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Material-UI), Relay, GraphQL, JWT, Node.js, Apache Cassandra.
 * [vslinko/ripster](https://github.com/vslinko/ripster/tree/master/src/graphql)
 * [relay-skeleton](https://github.com/fortruce/relay-skeleton) - React, Relay, GraphQL project skeleton
 * [simple-relay-starter](https://github.com/mhart/simple-relay-starter) - A very simple starter for React Relay using Browserify.


### PR DESCRIPTION
The isomorphic-material-relay-starter-kit is no longer supported and is superseded by the universal relay boilerplate. The new version adds react native to the mix.