### PR TITLE
Add jurassic-waves to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [Apollo Client documentation](http://docs.apollostack.com/apollo-client/) - Documentation and example for building GraphQL apps using apollo client
 * [Apollo Server tools documentation](http://docs.apollostack.com/apollo-server/) - Documentation, tutorial and examples for building GraphQL server and connecting to SQL, MongoDB and REST endpoints.
 * [f8app](https://github.com/fbsamples/f8app) - Source code of the official F8 app of 2016, powered by React Native and other Facebook open source projects. [http://makeitopen.com](http://makeitopen.com)
+* [jurrasic-waves](https://github.com/tdmckinn/jurastic-waves) - Example Dinosaur application using React, Relay, GraphQL, MongoDB, and react-router-relay.... Apollo Version soon.
 
 <a name="example-rb" />
 ### Ruby Examples


### PR DESCRIPTION
Demo application that shows off some of the relay and graphql features along with react-router-relay latest packages and updates. MongoDB on the backend and I plan to do a Apollo version soon with Redux as the state manager vs relay.