### PR TITLE
Updated README with 2 Java entries and a DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ If you want to contribute to this list (please do), send me a pull request.
 	- [Lua](#lib-lua)
 - [Tools](#tools)
 - [Services](#services)
+- [Databases](#databases)
 - [Examples](#example)
 	- [Javascript](#example-js)
 	- [Ruby](#example-rb)
@@ -200,6 +201,11 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Model Visualizer](http://nathanrandal.com/graphql-visualizer/) - A small webapp that generates an ERD-like visualization of a GraphQL endpoint from an introspection query.
 * [GraphQL Network](https://github.com/Ghirro/graphql-network) - A chrome dev-tools extension for debugging GraphQL network requests.
 * [eslint-plugin-graphql](https://github.com/apollostack/eslint-plugin-graphql) - An ESLint plugin that checks your GraphQL strings against a schema.
+
+<a name="databases" />
+## Databases
+
+* [Dgraph](https://dgraph.io/) - Scalable, distributed, low latency, high throughput Graph database with GraphQL as the query language
 
 <a name="services" />
 ## Services

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Java Libraries
 
 * [graphql-java](https://github.com/graphql-java/graphql-java) - GraphQL Java implementation.
+* [gaphql-java-type-generator](https://github.com/graphql-java/graphql-java-type-generator) - Auto-generates types for use with GraphQL Java
+* [graphql-java-annotations](https://github.com/graphql-java/graphql-java-annotations) - Provides annotations-based syntax for schema definition with GraphQL Java
 * [spring-graphql-common](https://github.com/oembedler/spring-graphql-common) - Spring Framework GraphQL Library.
 * [graphql-spring-boot](https://github.com/oembedler/graphql-spring-boot) - GraphQL and GraphiQL Spring Framework Boot Starters.
 


### PR DESCRIPTION
To provide a bit more juice to the Java section on this page, I added 2 projects that extend GraphQL Java that make it considerably easier and much less verbose to define your GraphQL schema.
And the really cool graph database DGraph.