### PR TITLE
`Step by step` tutorial how to migrate from REST to GraphQL using Angular2 and ApolloClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [f8app](https://github.com/fbsamples/f8app) - Source code of the official F8 app of 2016, powered by React Native and other Facebook open source projects. [http://makeitopen.com](http://makeitopen.com)
 * [Reindex Examples](https://github.com/reindexio/reindex-examples) - Example projects for Reindex with using React Native and React.js for web.
 * [Modelizr Documentation](julienvincent.github.io/modelizr) - Documentation and Usage Examples for modelizr
+* [angular2-graphql-rest](https://github.com/kamilkisiela/angular2-graphql-rest) - An example app with REST Api working side by side with GraphQL using Apollo Client with angular2-apollo. Includes step-by-step tutorial how to migrate from REST to GraphQL.
 
 <a name="example-rb" />
 ### Ruby Examples


### PR DESCRIPTION
### Angular2 with REST Api and GraphQL

An example app with REST Api working **side by side** with GraphQL using [**Apollo Client**](https://github.com/apollostack/apollo-client) with [**angular2-apollo**](https://github.com/apollostack/angular2-apollo).

#### Step by Step

I created a *step by step* process where you can see how to migrate from REST Api to just GraphQL.

You can find it on the [`steps`](https://github.com/kamilkisiela/angular2-graphql-rest/tree/steps) branch.

**Starting point** - Working App with REST Api

**`1.X`** - Creating GraphQL endpoint

**`2.X`** - Building an app where REST Api works side by side with GraphQL

**`3.X`** - Migrating to use only GraphQL