### PR TITLE
Add graphql-compose to javascript part

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-pouch](https://github.com/MikeBild/graphql-pouch) - A GraphQL-API runtime on top of PouchDB created by GraphQL shorthand notation as a self contained service with CouchDB synchronization.
 * [gql-tools](https://github.com/almilo/gql-tools) - Tool library with CLI for schema generation and manipulation.
 * [graphql-iso-date](https://github.com/excitement-engineer/graphql-iso-date) - A GraphQL date scalar type to be used with GraphQL.js. This scalar represents a date in the ISO 8601 format YYYY-MM-DD.
+* [graphql-compose](https://github.com/nodkz/graphql-compose) - Tool which allows you to construct flexible graphql schema from different data sources via plugins.
 
 ##### Relay Related
 


### PR DESCRIPTION
**[URL to the resource here.]**

https://github.com/nodkz/graphql-compose

**[Explain what this resource is all about and why it should be included here.]**

GraphQL-compose is an instrument which allows you to construct flexible graphql schema from different data sources via plugins. The main aim of graphql-compose to solve the problem of mash code in schema's files, and ridiculously simplify schema build process on server.