### PR TITLE
Add GraphJoiner

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [gql-tools](https://github.com/almilo/gql-tools) - Tool library with CLI for schema generation and manipulation.
 * [graphql-iso-date](https://github.com/excitement-engineer/graphql-iso-date) - A GraphQL date scalar type to be used with GraphQL.js. This scalar represents a date in the ISO 8601 format YYYY-MM-DD.
 * [graphql-compose](https://github.com/nodkz/graphql-compose) - Tool which allows you to construct flexible graphql schema from different data sources via plugins.
+* [node-graphjoiner](https://github.com/mwilliamson/node-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.
 
 ##### Relay Related
 
@@ -147,6 +148,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [django-graphiql](https://github.com/graphql-python/django-graphiql) - Integrate GraphiQL easily into your Django project.
 * [flask-graphql](https://github.com/graphql-python/flask-graphql) - Adds GraphQL support to your Flask application.
 * [python-graphql-client](https://github.com/graphcool/python-graphql-client) - Simple GraphQL client for Python 2.7+
+* [python-graphjoiner](https://github.com/healx/python-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.
 
 <a name="lib-java" />
 ### Java Libraries


### PR DESCRIPTION
This adds links to GraphJoiner implementations for both node.js and Python. This makes it easier to use joins, SQL or otherwise, to get the data you want. It also means you only run resolve functions once for each non-trivial in the request, rather than having to resolve every field in the response. This especially helps with large datasets: when we used the standard Python implementation of GraphQL, we found some requests took several seconds, and spent the vast majority of their time in the overhead of invoking resolvers. Using GraphJoiner brought response times to under a second. It's a bit of a shameless plug, but hopefully somebody else might find it useful!