### PR TITLE
Add vim-graphql to the Tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphQL Network](https://github.com/Ghirro/graphql-network) - A chrome dev-tools extension for debugging GraphQL network requests.
 * [eslint-plugin-graphql](https://github.com/apollostack/eslint-plugin-graphql) - An ESLint plugin that checks your GraphQL strings against a schema.
 * [AST Explorer](https://astexplorer.net/) - Select "GraphQL" at the top, explore the GraphQL AST and highlight different parts by clicking in the query.
+* [vim-graphql](https://github.com/jparise/vim-graphql) - A Vim plugin that provides GraphQL file detection and syntax highlighting.
 
 <a name="databases" />
 ## Databases


### PR DESCRIPTION
https://github.com/jparise/vim-graphql

vim-graphql is a Vim plugin that provides GraphQL file detection and
syntax highlighting.

"Tools" appears to be the best place for this currently, but it might
make sense to introduce an "Editors" list at some point.