### PR TITLE
add FetchQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-iso-date](https://github.com/excitement-engineer/graphql-iso-date) - A GraphQL date scalar type to be used with GraphQL.js. This scalar represents a date in the ISO 8601 format YYYY-MM-DD.
 * [graphql-compose](https://github.com/nodkz/graphql-compose) - Tool which allows you to construct flexible graphql schema from different data sources via plugins.
 * [node-graphjoiner](https://github.com/mwilliamson/node-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.
+* [FetchQL](https://github.com/gucheen/FetchQL) - GraphQL query client with Fetch
 
 ##### Relay Related
 


### PR DESCRIPTION
https://github.com/gucheen/FetchQL

FetchQL is a client of GraphQL that based on Fetch API.

- lightweight
- wrap query methods
- easily set server-side
- get enum types by names (with cache)
- built-in interceptors
- request state callbacks
- written in ES2015 and modules

