### PR TITLE
Add atom graphql-autocomplete to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [vim-graphql](https://github.com/jparise/vim-graphql) - A Vim plugin that provides GraphQL file detection and syntax highlighting.
 * [GraphQL CMS](https://github.com/sarkistlt/graphql-auto-generating-cms) - Use your existing GraphQL schema to generate simple for use, fully functional CMS in a couple steps.
 * [graphdoc](https://github.com/2fd/graphdoc) - Static page generator for documenting GraphQL Schema.
+* [graphql-autocomplete](https://github.com/nicolaslopezj/atom-graphql-autocomplete) - Autocomplete and lint from a GraphQL endpoint in Atom.
 
 <a name="databases" />
 ## Databases


### PR DESCRIPTION
**https://github.com/nicolaslopezj/atom-graphql-autocomplete**

It's a plugin for atom editor that enables autocomplete and lint, just like graphiql.

<img width="649" alt="example" src="https://cloud.githubusercontent.com/assets/2042567/20638251/81763c6e-b380-11e6-92bd-38d9960a213c.png">


