### PR TITLE
Add custom-graphiql to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphdoc](https://github.com/2fd/graphdoc) - Static page generator for documenting GraphQL Schema.
 * [graphql-autocomplete](https://github.com/nicolaslopezj/atom-graphql-autocomplete) - Autocomplete and lint from a GraphQL endpoint in Atom.
 * [GraphQL IDE](https://github.com/redound/graphql-ide) - An extensive IDE for exploring GraphQL API's.
+* [CustomGraphiQL](https://github.com/shahankit/custom-graphiql) - A custom wrapper around [graphiql](https://github.com/graphql/graphiql) package with extra utilities and allows to query any graphql endpoint. Inspired from [graphiql-app](https://github.com/skevy/graphiql-app) but within browser without requirement for an app.
 
 <a name="databases" />
 ## Databases

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Apollo GraphQL VSCode Extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) - Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform
 * [GRAPHQL DESIGNER](http://graphqldesigner.com/) - A developer's web-app tool to rapidly prototype a full stack CRUD implementation of GraphQL with React.
 * [GraphQL Inspector](https://graphql-inspector.com/) - Tooling for GraphQL. Compare schemas, validate documents, find breaking changes, find similar types, schema coverage.
-* [CustomGraphiQL](https://github.com/shahankit/custom-graphiql) - A custom wrapper around [graphiql](https://github.com/graphql/graphiql) package with extra utilities and allows to query any graphql endpoint. Inspired from [graphiql-app](https://github.com/skevy/graphiql-app) but within browser without requirement for an app.
+* [CustomGraphiQL](https://github.com/shahankit/custom-graphiql) - A custom wrapper around [graphiql](https://github.com/graphql/graphiql) package with extra utilities and allows to query any graphql endpoint.
 
 <a name="databases" />
 


### PR DESCRIPTION
custom-graphiql: https://github.com/shahankit/custom-graphiql

A custom wrapper around [graphiql](https://github.com/graphql/graphiql/) package 
which offers more utility button and a component which allows to query any graphql 
endpoint. Inspired from [graphiql-app](https://github.com/skevy/graphiql-app/) 
but within browser without requirement for an app.

