### PR TITLE
Add list of public GraphQL APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Facebook](https://www.facebook.com/groups/795330550572866/) - Group for discussions, articles and knowledge sharing
 * [Twitter](https://twitter.com/search?q=%23GraphQL) - Use the hashtag [#graphql](https://twitter.com/search?q=%23GraphQL)
 * [StackOverflow](http://stackoverflow.com/questions/tagged/graphql) - Questions and answers. Use the tag [graphql](http://stackoverflow.com/questions/tagged/graphql)
+* [GraphQL APIs](https://github.com/APIs-guru/graphql-apis) - A collective list of public GraphQL APIs
 
 <a name="lib" />
 ## Libraries


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/APIs-guru/graphql-apis

**[Explain what this resource is all about and why it should be included here.]**
Even hardcore Star Wars fans sometimes get tired and want to play with GraphQL APIs other than SWAPI proxy 😄 