### PR TITLE
Add Create-GraphQL, GraphQL-Pokémon & Relay-Pokémon

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ If you want to contribute to this list (please do), send me a pull request.
 * [node-graphjoiner](https://github.com/mwilliamson/node-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.
 * [FetchQL](https://github.com/gucheen/FetchQL) - GraphQL query client with Fetch
 * [Join Monster](https://github.com/stems/join-monster) - A GraphQL-to-SQL query execution layer for batch data fetching.
+* [Create-GraphQL](https://github.com/lucasbento/create-graphql) - Command-line utility to build production-ready servers with GraphQL.
+* [GraphQL-Pokémon](https://github.com/lucasbento/graphql-pokemon) - Get information of a Pokémon with GraphQL!
 
 ##### Relay Related
 
@@ -115,6 +117,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [react-relay-network-layer](https://github.com/nodkz/react-relay-network-layer) - A network layer for Relay with query batching and middleware support (urlThunk, retryThunk, auth, defer and other).
 * [relay-subscriptions](https://github.com/edvinerikson/relay-subscriptions) - Subscription support for Relay.
 * [Portfolio Relay Example](https://github.com/alex-cory/portfolio) - An example website that fetches data from various apis and uses Relay and GraphQL to feed the data to React components!
+* [Relay Pokédex](https://github.com/lucasbento/react-relay-pokemon) - Project using GraphQL Pokémon to show how powerful Relay is.
 
 <a name="lib-rb" />
 ### Ruby Libraries


### PR DESCRIPTION
Create-GraphQL - https://github.com/lucasbento/create-graphql
It's a simple command line utility that can initiate a whole project using GraphQL with KoaJS and generate:
- Types;
- Mutations;
- Relay Connections;
- Loaders (using Facebook's DataLoader);
- Tests (with the awesome Jest).

A very nice feature included is creating types and mutations from a Mongoose schema file, the CLI will parse the fields and generate a type and/or mutation accordingly. [Read more about it here.](https://medium.com/entria/announcing-create-graphql-17bdd81b9f96#.58hwludhq)

GraphQL-Pokémon - https://github.com/lucasbento/graphql-pokemon - https://graphql-pokemon.now.sh/
A GraphQL backend to query all the 150 Pokémon GO pokémons.

Relay Pokémon - https://github.com/lucasbento/react-relay-pokemon - https://react-relay-pokemon.now.sh/
A React & Relay project using GraphQL-Pokémon to show Pokémons and their evolutions.

