### PR TITLE
Add ArangoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ If you want to contribute to this list (please do), send me a pull request.
 <a name="databases" />
 ## Databases
 
+* [ArangoDB](https://www.arangodb.com/) - Multi-model database that supports GraphQL schemas in JavaScript inside the database.
 * [Dgraph](https://dgraph.io/) - Scalable, distributed, low latency, high throughput Graph database with GraphQL as the query language
 
 <a name="services" />


### PR DESCRIPTION
https://www.arangodb.com

ArangoDB is an Apache 2.0 licensed multi-model NoSQL database that allows developers to define their own embedded HTTP APIs on top of it using the built-in microservice framework Foxx running on V8. Foxx services have direct access to the database itself and thus scale with the database and can access the data in-memory, evading costly (de-)serialization and network overhead.

As of ArangoDB 3.1 the built-in JavaScript environment ships with a GraphQL integration: https://docs.arangodb.com/3/Manual/Foxx/GraphQL.html

This means Foxx services can define GraphQL schemas which can be directly resolved within the database.

Initial proof of concept for 3.0: https://www.arangodb.com/2016/02/using-graphql-nosql-database-arangodb/

Example use of the new integration: https://github.com/arangodb-foxx/demo-graphql/blob/master/index.js

Example schema: https://github.com/arangodb-foxx/demo-graphql/blob/master/schema.js