### PR TITLE
Add graphql-sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Create-GraphQL](https://github.com/lucasbento/create-graphql) - Command-line utility to build production-ready servers with GraphQL.
 * [GraphQL-Pokémon](https://github.com/lucasbento/graphql-pokemon) - Get information of a Pokémon with GraphQL!
 * [graphql-factory](https://github.com/graphql-factory) - Create GraphQL types from JSON definitions
+* [graphql-sync](https://github.com/arangodb/graphql-sync) - Promise-free wrapper to GraphQL.js for synchronous environments
 
 ##### Relay Related
 


### PR DESCRIPTION
https://github.com/arangodb/graphql-sync

`graphql-sync` replaces the outermost layer of GraphQL-js with purely synchronous code. This allows using GraphQL in JS environments that need code to be executed synchronously and therefore can't use promises (which are guaranteed to always be async).

The wrapper was written to implement the GraphQL integration in ArangoDB but is useful for other embedded environments that can't support asynchronous APIs.