### PR TITLE
Rename graphql-starter-kit to nodejs-api-starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [relay-starter-kit](https://github.com/relayjs/relay-starter-kit) - Barebones starting point for a Relay application.
 * [react-starter-kit](https://github.com/kriasoft/react-starter-kit) - Isomorphic web app boilerplate (Node.js/Express, GraphQL, React)
-* [graphql-starter-kit](https://github.com/kriasoft/graphql-starter-kit) - Project template for building a GraphQL server with Node.js v7+ and JavaScript
+* [nodejs-api-starter](https://github.com/kriasoft/nodejs-api-starter) - A boilerplate and tooling for building data API backends with Node.js, PostgreSQL and GraphQL
 * [swapi-graphql](https://github.com/graphql/swapi-graphql) - A GraphQL schema and server wrapping [swapi](http://swapi.co/).
 * [graphql-server](https://github.com/RisingStack/graphql-server) - GraphQL server with Mongoose (MongoDB) and Node.js.
 * [graphql-intro](https://github.com/clayallsopp/graphql-intro) - https://medium.com/@clayallsopp/your-first-graphql-server-3c766ab4f0a2


### PR DESCRIPTION
`graphql-starter-kit` was renamed to [nodejs-api-starter](https://github.com/kriasoft/nodejs-api-starter)