### PR TITLE
adding parse-graphql-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [FetchQL](https://github.com/gucheen/FetchQL) - GraphQL query client with Fetch
 * [Join Monster](https://github.com/stems/join-monster) - A GraphQL-to-SQL query execution layer for batch data fetching.
 * [graphql-factory](https://github.com/graphql-factory) - Create GraphQL types from JSON definitions
+* [GraphQL for Parse Server](https://github.com/bakery/parse-graphql-server) - GraphQL integration for Parse Server.
 
 ##### Relay Related
 


### PR DESCRIPTION
**https://github.com/bakery/parse-graphql-server**

**GraphQL integration for Parse Server, Useful for people who use [parse server](https://parseplatform.github.io) as their BaaS with GraphQL.
It allows controlling access to Parse models in resolvers using Parse ACL (Access Control List) system.**