### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphdoc](https://github.com/2fd/graphdoc) - Static page generator for documenting GraphQL Schema.
 * [graphql-autocomplete](https://github.com/nicolaslopezj/atom-graphql-autocomplete) - Autocomplete and lint from a GraphQL endpoint in Atom.
 * [GraphQL IDE](https://github.com/redound/graphql-ide) - An extensive IDE for exploring GraphQL API's.
+* [Swagger to GraphQL](https://github.com/yarax/swagger-to-graphql) - GraphQL types builder based on REST API described in Swagger. Allows to migrate to GraphQL from REST for 5 minutes
 
 <a name="databases" />
 ## Databases


### PR DESCRIPTION
https://github.com/yarax/swagger-to-graphql

swagger2graphql is a GraphQL wrapper over REST, which allows to migrate to GraphQL types very easily if you already have existing REST API described in Swagger schema