### PR TITLE
Add react-redux-apollo-authentication-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [GraphQL-CEP](https://github.com/sibelius/graphql-cep) - Query address by CEP
 * [Apollo React example for Github GraphQL API](https://github.com/katopz/react-apollo-graphql-github-example) - Usage Examples Apollo React for Github GraphQL API with create-react-app
 * [Intuitive GraphQL Resolver Example](https://github.com/xpepermint/graphql-example) - GraphQL application example using [contextable.js](https://github.com/xpepermint/contextablejs).
+* [react-redux-apollo-authenticaton-example](https://github.com/lnmunhoz/react-redux-apollo-authenticaton-example) - Authentication flow example using [Scaphold](http://scaphold.io) as a server
 
 <a name="example-ts" />
 ### TypeScript Examples


### PR DESCRIPTION
https://github.com/lnmunhoz/react-redux-apollo-authenticaton-example

I created this project to demonstrate how to setup the Scaphold server and authenticate using mutations + apollo client. Please let me know improvements to be added to the list. I want this to be a good reference.