### PR TITLE
Run awesome_bot only in changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - git diff master.. -U0 README.md | grep -Po "(?<=^\+).*" >> temp.md
+  - if (git diff master.. -U0 README.md | grep -Po "(?<=^\+).*"){ git diff master.. -U0 README.md | grep -Po "(?<=^\+).*" >> temp.md }
   - awesome_bot temp.md --allow-dupe --white-list medium,jacobwgillespie,wehavefaces,graphql.slack,vimeo,slideshare

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - if (git diff master.. -U0 README.md | grep -Po "(?<=^\+).*"){ git diff master.. -U0 README.md | grep -Po "(?<=^\+).*" >> temp.md }
+  - git diff master.. -U0 README.md | grep -Po "(?<=^\+).*" >> temp.md
   - awesome_bot temp.md --allow-dupe --white-list medium,jacobwgillespie,wehavefaces,graphql.slack,vimeo,slideshare

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-dupe --white-list medium,jacobwgillespie,wehavefaces,graphql.slack,vimeo,slideshare
+  - git diff master.. -U0 README.md | grep -Po "(?<=^\+).*" >> temp.md
+  - awesome_bot temp.md --allow-dupe --white-list medium,jacobwgillespie,wehavefaces,graphql.slack,vimeo,slideshare


### PR DESCRIPTION
This patch runs awesome_bot only in the additions/deletions and prevents PR from failing for other resources.
Should fix #157
( close #157 )