### PR TITLE
Add a link to graphql-apigen, fix a typo in graphql-java-type-generator.

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,13 +161,14 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Java Libraries
 
 * [graphql-java](https://github.com/graphql-java/graphql-java) - GraphQL Java implementation.
-* [gaphql-java-type-generator](https://github.com/graphql-java/graphql-java-type-generator) - Auto-generates types for use with GraphQL Java
+* [graphql-java-type-generator](https://github.com/graphql-java/graphql-java-type-generator) - Auto-generates types for use with GraphQL Java
 * [schemagen-graphql](https://github.com/bpatters/schemagen-graphql) - Schema generation and execution package that turns POJO's into a GraphQL Java queryable set of objects. Enables exposing any service as a GraphQL service using Annotations.
 * [graphql-java-annotations](https://github.com/graphql-java/graphql-java-annotations) - Provides annotations-based syntax for schema definition with GraphQL Java.
 * [spring-graphql-common](https://github.com/oembedler/spring-graphql-common) - Spring Framework GraphQL Library.
 * [graphql-spring-boot](https://github.com/oembedler/graphql-spring-boot) - GraphQL and GraphiQL Spring Framework Boot Starters.
 * [vertx-graphql-service-discovery](https://github.com/engagingspaces/vertx-graphql-service-discovery) - Asynchronous GraphQL service discovery and querying for your microservices.
 * [vertx-dataloader](https://github.com/engagingspaces/vertx-dataloader) - Port of Facebook DataLoader for efficient, asynchronous batching and caching in clustered GraphQL environments
+* [graphql-apigen](https://github.com/Distelli/graphql-apigen) - Generate Java interfaces from a GraphQL schema, then wire the implementations up with Guice or Spring. The eventual goal is to be a Java implementation of the concepts in [Apollo graphql-tools](https://github.com/apollostack/graphql-tools)
 
 <a name="lib-c" />
 ### C/C++ Libraries


### PR DESCRIPTION
**https://github.com/Distelli/graphql-apigen**

**Generate Java interfaces from GraphQL schemas and wire the implementations up with Guice or Spring**
