### PR TITLE
Adding WPGraphQL - Relay compliant GraphQL for WordPress

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [overblog/graphql-bundle](https://github.com/overblog/GraphQLBundle) - This bundle provides tools to build a complete GraphQL server in your Symfony App. Supports react-relay.
 * [GraphQL](https://github.com/Youshido/GraphQL) – Well documented PHP implementation with no dependencies.
 * [GraphQL Symfony Bundle](https://github.com/Youshido/GraphQLBundle) – GraphQL Bundle for the Symfony 3 (supports 2.6+).
+* [WPGraphQL](https://github.com/wp-graphql/wp-graphql) - WordPress plugin that exposes a Relay compliant GraphQL endpoint
 * [graphql-wp](https://github.com/tim-field/graphql-wp) – a WordPress plugin that exposes a GraphQL endpoint.
 * [eZ Platform GraphQL Bundle](https://www.symfony.fi/entry/graphql-bundle-adds-protocol-support-to-ez-platform-symfony-cms) - GraphQL Bundle for the eZ Platform Symfony CMS.
 * [GraphQL Middleware](https://github.com/stefanorg/graphql-middleware) - GraphQL Psr7 Middleware


### PR DESCRIPTION
**[https://github.com/wp-graphql/wp-graphql]**

**[WPGraphQL is a WordPress plugin that exposes a Relay-compliant `/graphql` endpoint. This should be included in the Awesome GraphQL list because it's an alternative to the other WordPress plugin on the list and offers a Relay Compliant structure.]**
