### PR TITLE
Add IRC channel to the community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ## Community
 
 * [Slack](https://graphql.slack.com/messages/general/) - Share and help people on the chat. Get your invite [here](https://graphql-slack.herokuapp.com/)
+* [`#graphql` on Freenode](https://webchat.freenode.net/?channels=#graphql) - The official IRC channel for GraphQL
 * [Facebook](https://www.facebook.com/groups/795330550572866/) - Group for discussions, articles and knowledge sharing
 * [Twitter](https://twitter.com/search?q=%23GraphQL) - Use the hashtag [#graphql](https://twitter.com/search?q=%23GraphQL)
 * [StackOverflow](http://stackoverflow.com/questions/tagged/graphql) - Questions and answers. Use the tag [graphql](http://stackoverflow.com/questions/tagged/graphql)


### PR DESCRIPTION
[Provided link](https://webchat.freenode.net/?channels=#graphql) is the webchat of Freenode pre-filled with the correct IRC channel.

This channel is small but genuine: Lee himself is sitting there and [Travis CI notifications are sent there](https://github.com/graphql/graphql-js/blob/master/.travis.yml#L16-L22).
