### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,15 @@ If you want to contribute to this list (please do), send me a pull request.
 * [StackOverflow](http://stackoverflow.com/questions/tagged/graphql) - Questions and answers. Use the tag [graphql](http://stackoverflow.com/questions/tagged/graphql)
 * [GraphQL APIs](https://github.com/APIs-guru/graphql-apis) - A collective list of public GraphQL APIs
 
+<a name="meetups" />
+## GraphQL Meetups
+
+* [Berlin](https://www.meetup.com/graphql-berlin)
+* [London](https://www.meetup.com/GraphQL-London)
+* [Melbourne](https://www.meetup.com/GraphQL-Melbourne)
+* [San Francisco](https://www.meetup.com/GraphQL-SF)
+* [Tel Aviv](https://www.meetup.com/GraphQL-TLV)
+
 <a name="lib" />
 ## Libraries
 


### PR DESCRIPTION
Added GraphQL Meetup groups section

Meetup groups are fundamental to the GraphQL community: organising regular events, attracting speakers and active contributors and engaging local user and developer groups.
