### PR TITLE
Fix link to Haskell library

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you want to contribute to this list (please do), send me a pull request.
 	- [Scala](#lib-scala)
 	- [.NET](#lib-dotnet)
 	- [Elixir](#lib-elixir)
-	- [Haskell] (#lib-haskell)
+	- [Haskell](#lib-haskell)
 	- [SQL](#lib-sql)
 	- [Lua](#lib-lua)
 	- [Elm](#lib-elm)


### PR DESCRIPTION
This is a fix to an existing link.
With this extra whitespace, this was showing as plain text and not a link.