### PR TITLE
Add lacinia to Clojure lib section

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Clojure Libraries
 
 * [graphql-clj](https://github.com/tendant/graphql-clj) - A Clojure library designed to provide GraphQL implementation.
+* [lacinia](https://github.com/walmartlabs/lacinia) - GraphQL implementation in pure Clojure.
 
 <a name="lib-swift" />
 ### Swift Libraries


### PR DESCRIPTION
http://lacinia.readthedocs.io/en/latest/

New, recently open-sourced GQL lib for Clojure by WalmartLabs.