### PR TITLE
Add graphql-dotnet/Conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### .NET Libraries
 
 * [graphql-dotnet](https://github.com/graphql-dotnet/graphql-dotnet) - GraphQL for .NET.
+* [Conventions](https://github.com/graphql-dotnet/conventions) - Reflection-based schema generation for .NET.
 * [graphql-net](https://github.com/ckimes89/graphql-net) - GraphQL to IQueryable for .NET
 * [FSharp.Data.GraphQL](https://github.com/fsprojects/FSharp.Data.GraphQL) - FSharp GraphQL.
 


### PR DESCRIPTION
**URL**
https://github.com/graphql-dotnet/Conventions

**Description**
[GraphQL .NET](https://github.com/graphql-dotnet/graphql-dotnet) has been around for a while. This library is a complementary layer on top that allows you to automatically wrap your .NET classes into GraphQL schema definitions using existing property getters and methods as field resolvers.
