### PR TITLE
GraphQL learning app built on GitHub's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [relay-chat](https://github.com/transedward/relay-chat) - an chat example showing Relay with routing and pagination.
 * [relay-todomvc](https://github.com/taion/relay-todomvc) - Relay TodoMVC with routing.
 * [graphql-express-sqlite](https://github.com/mrblueblue/graphql-express-sqlite) - GraphQL server with Sqlite and Express
+* [GraphQL-REST-wrapper-example](https://github.com/CalumForsterDev/graphql-js-example) Extremely short and easy GraphQL application built on top of the GitHub REST API with exercises to teach you GraphQL
 * [koa-graphql-relay-example](https://github.com/chentsulin/koa-graphql-relay-example) - Example of [koa-graphql](https://github.com/chentsulin/koa-graphql)
 * [relay-fullstack](https://github.com/lvarayut/relay-fullstack) - Relay Starter Kit integrated with Relay, GraphQL, Express, ES6/ES7, JSX, Webpack, Babel, Material Design Lite, and PostCSS.
 * [serverless-graphql-blog](https://github.com/serverless/serverless-graphql-blog) - A Serverless Blog leveraging GraphQL to offer a REST API with only 1 endpoint


### PR DESCRIPTION
[GraphQL-Example](https://github.com/CalumForsterDev/graphql-js-example)

This GraphQL application is 1 file and demonstrates how quick and easy it is to get started with GraphQL. The resolvers are built on top of the GitHub REST API and demonstrate how GraphQL can make many REST API calls to retrieve data. 

There are exercises at the end of the README for users to further develop their GraphQL knowledge.

