### PR TITLE
Add Yelp GraphQL Launch Blog Post

### DIFF
--- a/README.md
+++ b/README.md
@@ -491,6 +491,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [Github GraphQL API React Example](https://medium.com/@katopz/github-graphql-api-react-example-eace824d7b61)
 * [Testing a GraphQL Server using Jest](https://medium.com/entria/testing-a-graphql-server-using-jest-4e00d0e4980e)
 * [How to implement viewerCanSee in  GraphQL](https://medium.com/entria/how-to-implement-viewercansee-in-graphql-78cc48de7464)
+* [Introducing Yelp's Local Graph](https://engineeringblog.yelp.com/2017/05/introducing-yelps-local-graph.html)
 
 <a name="workshopper" />
 


### PR DESCRIPTION
https://engineeringblog.yelp.com/2017/05/introducing-yelps-local-graph.html

Yelp is a major data provider that's decided to support GraphQL directly, probably the biggest company to announce yet and more applications than GitHub's.
