### PR TITLE
Add jamesmacaulay/elm-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ If you want to contribute to this list (please do), send me a pull request.
 
 ### Elm Libraries
 
-* [elm-graphql](https://github.com/jahewson/elm-graphql) - GraphQL for Elm.
+* [jamesmacaulay/elm-graphql](https://github.com/jamesmacaulay/elm-graphql) - Client library that lets you build GraphQL queries in Elm.
+* [jahewson/elm-graphql](https://github.com/jahewson/elm-graphql) - Command-line tool that generates Elm code from queries in .graphql files.
 
 <a name="lib-clojure" />
 


### PR DESCRIPTION
Also added descriptions to differentiate the two Elm projects.

https://github.com/jamesmacaulay/elm-graphql

This is a package to support building GraphQL client applications in Elm. I am the creator of the project and I am actively maintaining it.
