### PR TITLE
Alumbra Clojure's library added

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [graphql-clj](https://github.com/tendant/graphql-clj) - A Clojure library designed to provide GraphQL implementation.
 * [lacinia](https://github.com/walmartlabs/lacinia) - GraphQL implementation in pure Clojure.
+* [alumbra](https://github.com/alumbra/alumbra) - Simple & Elegant GraphQL for Clojure!
 
 <a name="lib-clojurescript" />
 ### ClojureScript Libraries


### PR DESCRIPTION
Alumbra **https://github.com/alumbra/alumbra** Clojure's library.
Reference http://graphql.org/code/
