### PR TITLE
fix(README.md) Markdown structure improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [alumbra](https://github.com/alumbra/alumbra) - Simple & Elegant GraphQL for Clojure!
 
 <a name="lib-clojurescript" />
+
 ### ClojureScript Libraries
 
 * [speako](https://github.com/johanatan/speako) - A ClojureScript/NPM compiler for GraphQL Schema Language.


### PR DESCRIPTION
- Fix header “### ClojureScript Libraries” by adding empty line between HTML and Markdown.

## Description

One of the headers had missing linebreak before it, causing rendering issues for the Markdown header syntax, as there was HTML link on the line above it. Adding empty line fixes the Markdown rendering issue.


## Before
![screen shot 2017-05-25 at 23 41 05 d2s awesome-graphql tree patch-1 lib-clojure before](https://cloud.githubusercontent.com/assets/135053/26469760/dd12a7cc-41a3-11e7-8463-eb2f82324f6b.png)

## After
![screen shot 2017-05-25 at 23 41 30 d2s awesome-graphql tree patch-1 lib-clojure after](https://cloud.githubusercontent.com/assets/135053/26469764/def83106-41a3-11e7-856f-cb8dfd7add3e.png)



