### PR TITLE
add graphql client

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphiteJS](https://github.com/graphitejs/graphitejs) - Full stack GraphQL framework.
 * [loopback-graphql](https://github.com/tallyb/loopback-graphql) - GraphQL Server for Loopback.
 * [parasprite](https://github.com/octet-stream/parasprite) - Describe your GraphQL schema using chainable interface.
+* [GraphQL.js](https://github.com/f/graphql.js) - JavaScript GraphQL Client for Browser and Node.js Usage
 
 ##### Relay Related
 


### PR DESCRIPTION
https://github.com/f/graphql.js

Many libraries require complex stacks to make that simple request. In any project you don't use React, Relay, you'll need a simpler client which manages your query and makes a simple request. 

```js
// Connect...
var graph = graphql("/graphql")

// Prepare...
var allUsers = graph(`query { allUsers {id, name} }`)

// Run...
allUsers().then(function (users) {
  console.log(users)
})
```