### PR TITLE
Add graphql-guard ruby gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-parser](https://github.com/Shopify/graphql-parser) - A small ruby gem wrapping the libgraphqlparser C library for parsing GraphQL.
 * [graphql-client](https://github.com/github/graphql-client) - A Ruby library for declaring, composing and executing GraphQL queries.
 * [graphql-batch](https://github.com/Shopify/graphql-batch) - A query batching executor for the graphql gem.
+* [graphql-guard](https://github.com/exAspArk/graphql-guard) - A simple field-level authorization for the graphql gem.
 
 <a name="lib-php" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/exAspArk/graphql-guard

**[Explain what this resource is all about and why it should be included here.]**
It's a Ruby library which provides a field-level authorization for GraphQL. Previously, the only authorization solution for Ruby was [GraphQL Pro](http://graphql.pro/) which is a paid and not open-sourced library. I recently published a stable v1.0.0, my company uses it on production :)