### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,10 +530,10 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 
 <a name="workshopper" />
 
-## Workshoppers
+## Tutorials
 
+* [How to GraphQL](www.howtographql.com) - Fullstack Tutorial Website with Tracks for all Major Frameworks & Languages including React, Apollo, Relay, JavaScript, Ruby, Java, Elixir and many more 
 * [learning-graphql](https://github.com/mugli/learning-graphql) - An attempt to learn GraphQL.
-* [Let's Learn GraphQL](https://learngraphql.com) - Lessons/walkthrough of GraphQL concepts.
 * [Learn Relay](https://www.learnrelay.org/) - A comprehensive introduction to Relay
 * [Learn Apollo](https://www.learnapollo.com/) - A hands-on tutorial for Apollo GraphQL Client
 


### PR DESCRIPTION
* rename `Workshoppers` to `Tutorials`
* add How to GraphQL
* remove Learn GraphQL (offline & discontinued)

**[URL to the resource here.]**

- [How to GraphQL](www.howtographql.com)

**[Explain what this resource is all about and why it should be included here.]**

 - Fullstack Tutorial Website with Tracks for all Major Frameworks & Languages including React, Apollo, Relay, JavaScript, Ruby, Java, Elixir and many more 
