### PR TITLE
Update README.md - Add Spikenail framework URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphQL.js](https://github.com/f/graphql.js) - JavaScript GraphQL Client for Browser and Node.js Usage
 * [graphql-sync](https://github.com/arangodb/graphql-sync) - Promise-free wrapper to GraphQL.js for synchronous environments
 * [apollo-fetch](https://github.com/apollographql/apollo-fetch) - Lightweight GraphQL client that supports custom fetch functions, middleware, and afterware
+* [Spikenail](https://github.com/spikenail/spikenail) - Node.js framework for building GraphQL API almost without coding.
 
 ##### Relay Related
 


### PR DESCRIPTION
**https://github.com/spikenail/spikenail**

**Spikenail is an open-source Node.js ES7 framework which allows you to build GraphQL API with little or no coding.**
