### PR TITLE
Add Elm GraphQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Elm Libraries
 
 * [jamesmacaulay/elm-graphql](https://github.com/jamesmacaulay/elm-graphql) - Client library that lets you build GraphQL queries in Elm.
+* [ghivert/elm-graphql](https://github.com/ghivert/elm-graphql) - Client library that lets you build GraphQL queries in Elm with your own decoders.
 * [jahewson/elm-graphql](https://github.com/jahewson/elm-graphql) - Command-line tool that generates Elm code from queries in .graphql files.
 
 <a name="lib-clojure" />


### PR DESCRIPTION
# Url
[ghivert/elm-graphql](https://github.com/ghivert/elm-graphql)

# What is it?

Elm GraphQL is a client library focusing on writing queries for GraphQL for the moment. It fills the gap of easy writing of queries, without defining decoders, in opposite of [https://github.com/jamesmacaulay/elm-graphql] which defines decoders with the queries. It is a simple way to write GraphQL queries, and don't bother you with defining new types. It the simplest client library for GraphQL in Elm.
