### PR TITLE
Add link to a tool for generating a GraphQL schema from a relational DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [vertx-graphql-service-discovery](https://github.com/engagingspaces/vertx-graphql-service-discovery) - Asynchronous GraphQL service discovery and querying for your microservices.
 * [vertx-dataloader](https://github.com/engagingspaces/vertx-dataloader) - Port of Facebook DataLoader for efficient, asynchronous batching and caching in clustered GraphQL environments
 * [LiveGQL](https://github.com/Billy-Bichon/LiveGQL) - GraphQL subscription client in Java.
+* [rdbms-to-graphql](https://github.com/ebridges/rdbms-to-graphql) - A Java CLI program that generates a GraphQL schema from a JDBC data source.
 
 <a name="lib-c" />
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphpostgresQL](https://github.com/solidsnack/GraphpostgresQL) - GraphQL for Postgres.
 * [sql-to-graphql](https://github.com/rexxars/sql-to-graphql) - Generate a GraphQL API based on your SQL database structure.
 * [PostGraphQL](https://github.com/postgraphql/postgraphql) - A GraphQL schema created by reflection over a PostgreSQL schema.
+* [rdbms-to-graphql](https://github.com/ebridges/rdbms-to-graphql) - A Java CLI program that generates a GraphQL schema from a JDBC data source.
 
 <a name="lib-lua" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/ebridges/rdbms-to-graphql

**[Explain what this resource is all about and why it should be included here.]**
 A Java CLI program that generates a GraphQL schema from a JDBC data source.  

There currently is not a tool for introspecting on a database to generate a SQL.  This tool establishes relationships between entities by actually following foreign keys in the DB (vs. doing so via inferring relationships by column naming conventions).