### PR TITLE
Add json-graphql-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Altair GraphQL Client](https://github.com/imolorhe/altair) - An sleek graphQL client app for querying GraphQL servers, like Postman for graphQL. It also comes as a chrome extension.
 * [Apollo Storybook Decorator](https://github.com/abhiaiyer91/apollo-storybook-decorator) - Wrap your React Storybook stories with Apollo Client, provide mocks for isolated UI testing with GraphQL
 * [GraphQL Metrics](https://github.com/Workpop/graphql-metrics) - instrument GraphQL resolvers, logging response times and statuses (if there was an error or not) to the console as well as to InfluxDB.
-
+* [json-graphql-server](https://github.com/marmelab/json-graphql-server) - Get a full fake GraphQL API with zero coding in less than 30 seconds, based on a JSON data file.
 
 
 <a name="databases" />


### PR DESCRIPTION
https://github.com/marmelab/json-graphql-server

This tools helps GraphQL frontend developers to start playing with GraphQL right away. All it takes is a JSON of their data. It's ideal for testing and mocking a GraphQL server.

Inspired by the excellent [json-server](https://github.com/typicode/json-server).
