### PR TITLE
Add batch-loader Ruby gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-parser](https://github.com/Shopify/graphql-parser) - A small ruby gem wrapping the libgraphqlparser C library for parsing GraphQL.
 * [graphql-client](https://github.com/github/graphql-client) - A Ruby library for declaring, composing and executing GraphQL queries.
 * [graphql-batch](https://github.com/Shopify/graphql-batch) - A query batching executor for the graphql gem.
+* [batch-loader](https://github.com/exaspark/batch-loader) – A powerful tool to avoid N+1 queries without extra dependencies or primitives.
 
 <a name="lib-php" />
 
@@ -432,7 +433,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [github-graphql-rails-example](https://github.com/github/github-graphql-rails-example) - Example Rails app using GitHub's GraphQL API.
 * [relay-on-rails](https://github.com/nethsix/relay-on-rails) - Barebones starter kit for Relay application with Rails GraphQL server.
 * [relay-rails-blog](https://github.com/gauravtiwari/relay-rails-blog) - A graphql, relay and standard rails application powered demo weblog.
-* [to_eat_app] (https://github.com/jcdavison/to_eat_app) - A sample graphql/rails/relay application with a related 3-part article series.
+* [to_eat_app](https://github.com/jcdavison/to_eat_app) - A sample graphql/rails/relay application with a related 3-part article series.
 
 <a name="example-go" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/exAspArk/batch-loader

**[Explain what this resource is all about and why it should be included here.]**
[batch-loader](https://github.com/exaspark/batch-loader) is a tool to avoid N+1 DB queries, HTTP requests, etc. In addition to the detailed description and some ASCII art in the [README](https://github.com/exAspArk/batch-loader/blob/master/README.md) I also created a small presentation. I used the [slides](https://speakerdeck.com/exaspark/batching-the-powerful-way-to-solve-n-plus-1-queries-every-rubyist-should-know) to describe to my internal team what is batching and why the gem was created.

The gem can be used with any Ruby code and it may be very useful. For example, in our company during the migration from RESTful API to GraphQL within the 6 years old Rails application we're able to reuse the same code with `batch-loader` to avoid N+1 queries.