### PR TITLE
Add Insomnia REST Client to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Apollo Storybook Decorator](https://github.com/abhiaiyer91/apollo-storybook-decorator) - Wrap your React Storybook stories with Apollo Client, provide mocks for isolated UI testing with GraphQL
 * [GraphQL Metrics](https://github.com/Workpop/graphql-metrics) - instrument GraphQL resolvers, logging response times and statuses (if there was an error or not) to the console as well as to InfluxDB.
 * [json-graphql-server](https://github.com/marmelab/json-graphql-server) - Get a full fake GraphQL API with zero coding in less than 30 seconds, based on a JSON data file.
+* [Insomnia](https://insomnia.rest/) – An full-featured API client with first-party GraphQL query editor
 
 
 <a name="databases" />


### PR DESCRIPTION
Insomnia [now supports GraphQL](https://insomnia.rest/blog/introducing-graphql/) as a request body type, very similar to GraphiQL.