### PR TITLE
Add venia to clojurescript libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### ClojureScript Libraries
 
 * [speako](https://github.com/johanatan/speako) - A ClojureScript/NPM compiler for GraphQL Schema Language.
+* [venia](https://github.com/Vincit/venia) - A Clojure(Script) GraphQL query generation
 
 <a name="lib-swift" />
 


### PR DESCRIPTION
**https://github.com/Vincit/venia**

Venia is library for GraphQL query generation from Clojure data which allows to avoid strings concatenations and manipulations when using GraphQL. It supports both client and server side.  
