### PR TITLE
Update README.md with `gnt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-sync](https://github.com/arangodb/graphql-sync) - Promise-free wrapper to GraphQL.js for synchronous environments
 * [apollo-fetch](https://github.com/apollographql/apollo-fetch) - Lightweight GraphQL client that supports custom fetch functions, middleware, and afterware
 * [Spikenail](https://github.com/spikenail/spikenail) - Node.js framework for building GraphQL API almost without coding.
-
+* [gnt](https://github.com/mfix22/gnt) - Normalize your data with GraphQL types
 ##### Relay Related
 
 * [relay](https://github.com/facebook/relay) - Relay is a JavaScript framework for building data-driven React applications.


### PR DESCRIPTION
https://github.com/mfix22/gnt

The **G**in-**n**-**T**onic of GraphQL Types
- GraphQL Normalized Types: keep your data normal with `gnt`. Never think about these types again. 
- Looking for collaborators to keep adding types!
- Already includes: 
  - `credit-card`
  - `non-empty-string`
  - `phone`
  - `unix-date`
  - `us-state`
  - `zipcode`
