### PR TITLE
Update README.md with `gest`

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphQL Rover](https://github.com/Brbb/graphql-rover) - GraphQL schema interactive navigation, rearrange nodes, search and explore types and fields.
 * [json-graphql-server](https://github.com/marmelab/json-graphql-server) - Get a full fake GraphQL API with zero coding in less than 30 seconds, based on a JSON data file.
 * [Insomnia](https://insomnia.rest/) – An full-featured API client with first-party GraphQL query editor
-
+* [gest](https://github.com/mfix22/gest) - Sensible GraphQL testing tool for all phases of testing
 <a name="databases" />
 
 ## Databases


### PR DESCRIPTION
https://github.com/mfix22/gest

- `gest` is a testing tool for GraphQL that makes unit, integration, deployment, and regression testing your GraphQL schema easy
- With JavaScript, there is no need to restart your dev server or GraphiQL to test your schema changes
- Helpful CLI utilities like printing your schema (colorfully!) and pretty-printing queries (so you don't have to use GraphiQL to prettify)
