### PR TITLE
Add FriendsRadio to Javascript examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [ReactQL starter kit](https://reactql.org) - Universal React + Apollo + Redux + React Router 4, with SSR-enabled GraphQL, store (de/re)hydration and production code bundling.
 * [microhn](https://github.com/stubailo/microhn) - Simple Hacker News client built on top of GraphQLHub
 * [Apollo Web&Mobile Universal Starter Kit with Hot Code Reload](https://github.com/sysgears/apollo-universal-starter-kit) -  Apollo, GraphQL, React, React Native, Expo, Redux, Express, SQL and Twitter Bootstrap. Hot Code Reload of back end & front end using Webpack and Hot Module Replacement.
-
+* [FriendsRadio](https://github.com/xouabita/friends-radio) - Stream and share music with friends. Powered by Razzle, React and Apollo.
 <a name="example-ts" />
 
 ### TypeScript Examples


### PR DESCRIPTION
**https://github.com/xouabita/friends-radio**

**FriendsRadio is an example application built with Razzle, React and Apollo.**
