### PR TITLE
Added kotlin category and a ktq Kotlin client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ If you want to contribute to this list (please do), send me a pull request.
 	- [Rust](#lib-rust)
 	- [R](#lib-r)
 	- [Julia](#lib-julia)
+	- [Kotlin](#lib-kotlin)
 - [Tools](#tools)
 - [Services](#services)
 - [Databases](#databases)
@@ -344,6 +345,12 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Julia Libraries
 
 * [Diana.jl](https://github.com/codeneomatrix/Diana.jl) -  Julia client for GraphQL.
+
+<a name="lib-kotlin" />
+
+### Kotlin Libraries
+
+* [ktq](https://github.com/prestongarno/ktq) - Kotlin gradle plugin SDL type generator & runtime client
 
 <a name="tools" />
 


### PR DESCRIPTION
https://github.com/prestongarno/ktq

A library for writing kotlin apps to interact with a GraphQL server. Related gradle plugin (not added to this list) generates kotlin type hierarchy mirroring a GraphQL schema. Runtime client is strictly-typed, asynchronous (can also use kotlin co-routines), and thoroughly tested going into version 0.2.1 