### PR TITLE
added link to graphql-weaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-sync](https://github.com/arangodb/graphql-sync) - Promise-free wrapper to GraphQL.js for synchronous environments
 * [apollo-fetch](https://github.com/apollographql/apollo-fetch) - Lightweight GraphQL client that supports custom fetch functions, middleware, and afterware
 * [Spikenail](https://github.com/spikenail/spikenail) - Node.js framework for building GraphQL API almost without coding.
+* [graphql-weaver](https://github.com/AEB-labs/graphql-weaver) - A tool to combine, link and transform GraphQL schemas; combine multiple GraphQL servers into one API.
 
 ##### Relay Related
 


### PR DESCRIPTION
**https://github.com/AEB-labs/graphql-weaver**

**This tool allows you to easily combine multiple, independent GraphQL servers into a single unified API. You can even define relationships between schemas that can be queried and graphql-weaver will transparently forward the requests to the underlying servers, and combine the results automatically.**

**Why create a specific GraphQL gateway server when you can create a group of GraphQL microservices and easily combine them into one with no extra code!**
