### PR TITLE
Add API Platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [graphql-php](https://github.com/webonyx/graphql-php) - A PHP port of GraphQL reference implementation.
 * [graphql-relay-php](https://github.com/ivome/graphql-relay-php) - Relay helpers for GraphQL & PHP.
+* [API Platform](https://github.com/api-platform/api-platform) - API framework compatible with Symfony having native GraphQL support.
 * [laravel-graphql](https://github.com/Folkloreatelier/laravel-graphql) - Facebook GraphQL for Laravel 5.
 * [laravel-graphql-relay](https://github.com/nuwave/laravel-graphql-relay) - A Laravel library to help construct a server supporting react-relay.
 * [graphql-mapper](https://github.com/4rthem/graphql-mapper) - This library allows to build a GraphQL schema based on your model.


### PR DESCRIPTION
https://github.com/api-platform/api-platform

API Platform is a popular PHP and JavaScript framework to create API-first projects. The last version has native GraphQL support: [screencast](https://twitter.com/dunglas/status/916202649380425728).

To create a GraphQL API, you just have to modelize the schema as a set of plain old PHP classes. API Platform takes care of everything else.