### PR TITLE
Add GraphQL Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,6 +364,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ## Tools
 
 * [graphiql](https://github.com/graphql/graphiql) - An in-browser IDE for exploring GraphQL.
+* [GraphQL Playground](https://github.com/graphcool/graphql-playground) - GraphQL IDE that supports multi-column schema docs, tabs, query history, configuration of HTTP headers and GraphQL Subscriptions.
 * [GraphiQL.app](https://github.com/skevy/graphiql-app) - A light, Electron-based wrapper around GraphiQL.
 * [GraphQLviz](https://github.com/Macroz/GraphQLviz) - GraphQLviz marries GraphQL (schemas) with Graphviz.
 * [graphqlviz](https://github.com/sheerun/graphqlviz) - GraphQL API visualizer in Node.js


### PR DESCRIPTION
https://github.com/graphcool/graphql-playground

GraphQL Playground is an IDE for GraphQL just like GraphiQL but better (local) development workflows. It has multi-column schema documentation, automatic schema reloading, query history
configuration of HTTP headers, tabs and support for GraphQL Subscriptions.