### PR TITLE
docs: Add link for Toronto GraphQL Meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Tel Aviv](https://www.meetup.com/GraphQL-TLV/)
 * [Buenos Aires](https://www.meetup.com/es-ES/GraphQL-BA/)
 * [Munich](https://www.meetup.com/GraphQL-Munich/)
+* [Toronto](https://www.meetup.com/GraphQL-Toronto/)
 
 <a name="lib" />
 


### PR DESCRIPTION
https://www.meetup.com/GraphQL-Toronto/

Link to the GraphQL Toronto Meetup page.
