### PR TITLE
Correct entry on Dgraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ## Databases
 
 * [ArangoDB](https://www.arangodb.com/) - Multi-model database that supports GraphQL schemas in JavaScript inside the database.
-* [Dgraph](https://dgraph.io/) - Scalable, distributed, low latency, high throughput Graph database with GraphQL as the query language
+* [Dgraph](https://dgraph.io/) - Scalable, distributed, low latency, high throughput Graph database with a GraphQL like language (called [GraphQL+](https://docs.dgraph.io/query-language/)) as the query language. Dgrapqh can be queried with graphql by using [dgraphql](https://github.com/dpeek/dgraphql)
 
 <a name="services" />
 


### PR DESCRIPTION
The query language for Dgraph is now GraphQL+, not GraphQL. You have to use another library to bridge the gap between regular GraphQL and Dgraph.
