### PR TITLE
Add graphql-sequelize-crud to JavaScript libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [codemirror-graphql](https://github.com/graphql/codemirror-graphql) - GraphQL mode and helpers for CodeMirror.
 * [graphql-schema](https://github.com/devknoll/graphql-schema) - Create GraphQL schemas with a fluent/chainable interface.
 * [graphql-sequelize](https://github.com/mickhansen/graphql-sequelize) - Sequelize helpers for GraphQL.
+* [graphql-sequelize-crud](https://github.com/Glavin001/graphql-sequelize-crud) - Automatically generate queries and mutations from Sequelize models.
 * [graffiti](https://github.com/RisingStack/graffiti) - Node.js GraphQL ORM.
 * [graffiti-mongoose](https://github.com/RisingStack/graffiti-mongoose) - Mongoose (MongoDB) adapter for graffiti (Node.js GraphQL ORM).
 * [babel-plugin-graphql](https://github.com/ooflorent/babel-plugin-graphql) - Babel plugin that compile GraphQL tagged template strings.


### PR DESCRIPTION
# Where

https://github.com/Glavin001/graphql-sequelize-crud

# About

Automatically generate queries and mutations from Sequelize models!

## Demo

https://github.com/Glavin001/graphql-sequelize-crud/blob/master/demo/index.ts

# Why

- :white_check_mark: Less error prone development. No more keeping GraphQL in sync with Database fields.
- :white_check_mark: [Don't Repeat Yourself](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself).
- :white_check_mark: Power of GraphQL and Relay with rapid database development of Sequelize


---

**Note:** Since [graphql-sequelize-crud](https://github.com/Glavin001/graphql-sequelize-crud) is extremely related to [graphql-sequelize](https://github.com/mickhansen/graphql-sequelize) -- users of one would likely be interested in the other -- I put them close to each other. Let me know if this should be changed.