### PR TITLE
Add C# GraphQL.Client to list of available Open Source Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Conventions](https://github.com/graphql-dotnet/conventions) - Reflection-based schema generation for .NET.
 * [graphql-net](https://github.com/ckimes89/graphql-net) - GraphQL to IQueryable for .NET
 * [FSharp.Data.GraphQL](https://github.com/fsprojects/FSharp.Data.GraphQL) - FSharp GraphQL.
-* [GraphQL.Client](https://github.com/deinok/GraphQL.Client) - GraphQL Client for .NET.
+* [GraphQL.Client](https://github.com/graphql-dotnet/graphql-client) - GraphQL Client for .NET.
 
 <a name="lib-erlang" />
 

--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Conventions](https://github.com/graphql-dotnet/conventions) - Reflection-based schema generation for .NET.
 * [graphql-net](https://github.com/ckimes89/graphql-net) - GraphQL to IQueryable for .NET
 * [FSharp.Data.GraphQL](https://github.com/fsprojects/FSharp.Data.GraphQL) - FSharp GraphQL.
+* [GraphQL.Client](https://github.com/deinok/GraphQL.Client) - GraphQL Client for .NET.
 
 <a name="lib-erlang" />
 


### PR DESCRIPTION
https://github.com/graphql-dotnet/graphql-client

It's a Client for GraphQL for all the .NET plataforms.
It is already pushed to NuGet and is available via Package Managers.
