### PR TITLE
Add `blips` to js libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-resolvers](https://github.com/lucasconstantino/graphql-resolvers) - Resolver composition library for GraphQL.
 * [apollo-resolvers](https://github.com/thebigredgeek/apollo-resolvers) - Expressive and composable resolvers for Apollo Server and graphql-tools.
 * [apollo-errors](https://github.com/thebigredgeek/apollo-errors) - Machine-readable custom errors for Apollo Server.
+* [blips](https://github.com/monojack/blips) - Application state management with GraphQL
 
 ##### Relay Related
 


### PR DESCRIPTION
**[blips](https://github.com/monojack/blips)**

**Blips is a JS client for managing application state with GraphQL operations. It also provides a custom directive for talking to a GraphQL API**
