### PR TITLE
Adding Rejoiner

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [vertx-dataloader](https://github.com/engagingspaces/vertx-dataloader) - Port of Facebook DataLoader for efficient, asynchronous batching and caching in clustered GraphQL environments
 * [LiveGQL](https://github.com/Billy-Bichon/LiveGQL) - GraphQL subscription client in Java.
 * [rdbms-to-graphql](https://github.com/ebridges/rdbms-to-graphql) - A Java CLI program that generates a GraphQL schema from a JDBC data source.
+* [Rejoiner](https://github.com/google/rejoiner) - Generates a GraphQL schema based on one or more gRPC microservices, or any other Protobuf source.
 
 <a name="lib-c" />
 


### PR DESCRIPTION
https://github.com/google/rejoiner

Generates a uniform GraphQL schema based on one or more gRPC microservices, or any other Protobuf source. This lightweight GraphQL frontend server acts as a gateway dispatching requests to gRPC backend servers.