### PR TITLE
added minimal graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graysql-orm-loader](https://github.com/larsbs/graysql-orm-loader) - A GraysQL extension to load a GraphQL schema from an ORM.
 * [Annotated GraphQL](https://github.com/almilo/annotated-graphql) - Proof of Concept for annotations in GraphQL (i.e.: transform an existing REST api into a GraphQL endpoint).
 * [Apollo Client](https://github.com/apollographql/apollo-client) - A well-documented GraphQL client. Has React and Angular bindings.
+* [Minimal Graphql](https://github.com/ZaninAndrea/minimalGraphql) - Minimal graphql node client based on Apollo Client
 * [graphql-tools](https://github.com/apollographql/graphql-tools) - Tool library for building and maintaining GraphQL-JS servers.
 * [graphql-anywhere](https://github.com/apollographql/graphql-anywhere) - Run a GraphQL query anywhere, against any data, with no schema.
 * [graphql-tag](https://github.com/apollographql/graphql-tag) - A JavaScript template literal tag that parses GraphQL queries.


### PR DESCRIPTION
Included [minimal graphql](https://github.com/ZaninAndrea/minimalGraphql): a minimal graphql node client based on Apollo.