### PR TITLE
Adding Perl category and 2 Perl libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ If you want to contribute to this list (please do), send me a pull request.
 	- [C/C++](#lib-c)
 	- [Go](#lib-go)
 	- [Scala](#lib-scala)
+	- [Perl](#lib-perl)	
 	- [.NET](#lib-dotnet)
 	- [Erlang](#lib-erlang)
 	- [Elixir](#lib-elixir)
@@ -258,6 +259,13 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-scala](https://github.com/hrosenhorn/graphql-scala) - An attempt to get GraphQL going with Scala.
 
 <a name="lib-dotnet" />
+
+### Perl Libraries
+
+* [Perl6-GraphQL](https://github.com/CurtTilmes/Perl6-GraphQL) - GraphQL for Perl6.
+* [graphql-perl](https://github.com/graphql-perl/graphql-perl) - GraphQL for Perl5.
+
+<a name="lib-perl" />
 
 ### .NET Libraries
 

--- a/README.md
+++ b/README.md
@@ -258,14 +258,14 @@ If you want to contribute to this list (please do), send me a pull request.
 * [sangria-relay](https://github.com/sangria-graphql/sangria-relay) - Sangria Relay Support.
 * [graphql-scala](https://github.com/hrosenhorn/graphql-scala) - An attempt to get GraphQL going with Scala.
 
-<a name="lib-dotnet" />
+<a name="lib-perl" />
 
 ### Perl Libraries
 
 * [Perl6-GraphQL](https://github.com/CurtTilmes/Perl6-GraphQL) - GraphQL for Perl6.
 * [graphql-perl](https://github.com/graphql-perl/graphql-perl) - GraphQL for Perl5.
 
-<a name="lib-perl" />
+<a name="lib-dotnet" />
 
 ### .NET Libraries
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/CurtTilmes/Perl6-GraphQL
https://github.com/graphql-perl/graphql-perl

**[Explain what this resource is all about and why it should be included here.]**
added Perl category and 2 main libraries for a Perl 5 and Perl 6 implementation of GraphQL