### PR TITLE
add Graphql Disable Introspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-resolvers](https://github.com/lucasconstantino/graphql-resolvers) - Resolver composition library for GraphQL.
 * [apollo-resolvers](https://github.com/thebigredgeek/apollo-resolvers) - Expressive and composable resolvers for Apollo Server and graphql-tools.
 * [apollo-errors](https://github.com/thebigredgeek/apollo-errors) - Machine-readable custom errors for Apollo Server.
+* [graphql-disable-introspection](https://github.com/helfer/graphql-disable-introspection) - Graphql Disable Introspection
 
 ##### Relay Related
 


### PR DESCRIPTION
https://github.com/helfer/graphql-disable-introspection

Disable introspection queries in GraphQL with a simple validation rule. Queries that contain __schema or __type will fail validation with this rule. For example, the following queries will be rejected
