### PR TITLE
removed django-graphiql since it's deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,6 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-parser-python](https://github.com/tallstreet/graphql-parser-python) - A python wrapper around libgraphqlparser.
 * [graphene](https://github.com/graphql-python/graphene) - A package for creating GraphQL schemas/types in a Pythonic easy way.
 * [graphene-gae](https://github.com/graphql-python/graphene-gae) - Adds GraphQL support to Google AppEngine (GAE).
-* [django-graphiql](https://github.com/graphql-python/django-graphiql) - Integrate GraphiQL easily into your Django project.
 * [flask-graphql](https://github.com/graphql-python/flask-graphql) - Adds GraphQL support to your Flask application.
 * [python-graphql-client](https://github.com/graphcool/python-graphql-client) - Simple GraphQL client for Python 2.7+
 * [python-graphjoiner](https://github.com/healx/python-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/graphql-python/django-graphiql

**[Explain what this resource is all about and why it should be included here.]**

It states clearly in the description of the project:

> [DEPRECATED | Use graphene-django package] Integrate GraphiQL easily into your Django project
