### PR TITLE
Rename graphcool framework to prisma

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphQL Rover](https://github.com/Brbb/graphql-rover) - GraphQL schema interactive navigation, rearrange nodes, search and explore types and fields.
 * [json-graphql-server](https://github.com/marmelab/json-graphql-server) - Get a full fake GraphQL API with zero coding in less than 30 seconds, based on a JSON data file.
 * [Insomnia](https://insomnia.rest/) – An full-featured API client with first-party GraphQL query editor
-* [Graphcool Framework](https://github.com/graphcool/framework) - Framework to develop and deploy serverless GraphQL backends.
+* [Prisma](https://github.com/graphcool/prisma) - Turn your database into a GraphQL API. Prisma lets you design your data model and have a production ready GraphQL API online in minutes.
 * [tuql](https://github.com/bradleyboy/tuql) - Automatically create a GraphQL server from any sqlite database.
 
 <a name="databases" />


### PR DESCRIPTION
**https://github.com/graphcool/prisma**

Graphcool Framework was released as v1.0 called Prisma today.

Their plan seems to be to offer Prisma as open source technology to enable building GraphQL APIs and still offering their Graphcool cloud as a managed solution. So it would be right to let Graphcool under Services unchanged.

Also, the current link https://github.com/graphcool/framework already redirects to the prisma repo.

See also https://blog.graph.cool/introducing-prisma-1ff423fd629e