### PR TITLE
Add link to type-o-rama

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [apollo-resolvers](https://github.com/thebigredgeek/apollo-resolvers) - Expressive and composable resolvers for Apollo Server and graphql-tools.
 * [apollo-errors](https://github.com/thebigredgeek/apollo-errors) - Machine-readable custom errors for Apollo Server.
 * [mongo-graphql-starter](https://github.com/arackaf/mongo-graphql-starter) - Flexible and robust Mongo based resolvers for Node.
+* [type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability.
 
 ##### Relay Related
 


### PR DESCRIPTION
[type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability.

It lists tools which can convert GraphQL definitions to JS type systems, like TypeScript, Flow etc.
