### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [apollo-resolvers](https://github.com/thebigredgeek/apollo-resolvers) - Expressive and composable resolvers for Apollo Server and graphql-tools.
 * [apollo-errors](https://github.com/thebigredgeek/apollo-errors) - Machine-readable custom errors for Apollo Server.
 * [mongo-graphql-starter](https://github.com/arackaf/mongo-graphql-starter) - Flexible and robust Mongo based resolvers for Node.
+* [typegql](https://github.com/prismake/typegql) - Create graphql schema with classes and decorators
 
 ##### Relay Related
 


### PR DESCRIPTION
I've added link to `typegql` library.

With `typegql` to create schema:

```graphql
{
  hello(name: "Bob") # will resolve to 'Hello, Bob!'
}
```

Code needed is:

```
import { Schema, Query, compileSchema } from 'typegql';

@Schema()
class SuperSchema {
  @Query()
  hello(name: string): string {
    return `Hello, ${name}!`;
  }
}
```

If wrote with typescript, all types are inferred automatically.
const compiledSchema = compileSchema(SuperSchema);