### PR TITLE
Added video link

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 
 ## Videos
 
+* [Zero-config Apollo + GraphQL with Apollo Boost](https://egghead.io/lessons/react-zero-config-apollo-graphql-with-apollo-boost)
 * [Zero to GraphQL in 30 Minutes](https://www.youtube.com/embed/UBGzsb2UkeY)
 * [Data fetching for React applications at Facebook](https://www.youtube.com/watch?v=9sc8Pyc51uU)
 * [React Native & Relay: Bringing Modern Web Techniques to Mobile](https://www.youtube.com/watch?v=X6YbAKiLCLU)


### PR DESCRIPTION
Egghead.io Zero-config Apollo + GraphQL with Apollo Boost video link

https://egghead.io/lessons/react-zero-config-apollo-graphql-with-apollo-boost

The video is a quick intro on how to refactor a simple Apollo + GraphQL to use Apollo Boost. 
