### PR TITLE
Adds Hasura as a GraphQL on postgres "service"

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [GraphCMS](https://graphcms.com/) - GraphQL based Headless Content Management System.
 * [Graphcool](https://www.graph.cool/) - Your own GraphQL backend in under 5 minutes. Works with every GraphQL client such as Relay and Apollo.
+* [Hasura](https://hasura.io/) - Create tables and get a GraphQL backend in under 60s. Works on top of Postgres that you can directly access. No initial knowledge of graphql required.
 * [Reindex](https://www.reindex.io/) - Instant GraphQL Backend for Your React Apps.
 * [Scaphold](https://scaphold.io/) - GraphQL as a service that includes API integrations such as Stripe and Mailgun.
 * [Tipe](https://tipe.io/) - Next Generation API-first CMS with a GraphQL or REST API. Stop letting your CMS decide how you build your apps.


### PR DESCRIPTION
**[URL to the resource here.]**
https://hasura.io

**[Explain what this resource is all about and why it should be included here.]**
Hasura provides a GraphQL service on top of Postgres. It makes it easy for developers to use GraphQL in their apps without having to write a backend or even write a GraphQL schema. 