### PR TITLE
changed GraphStack name since it was re-brended

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### TypeScript Libraries
 
 * [TypeGraphQL](https://github.com/19majkel94/type-graphql) - Create GraphQL schema and resolvers with TypeScript, using classes and decorators!
-* [GraphStack]() - NodeJS framework that helps you to create scalable, maintainable, extensible, declarative and fast GraphQL-based server applications.
+* [Vesper](http://vesper-framework.com) - NodeJS framework that helps you to create scalable, maintainable, extensible, declarative and fast GraphQL-based server applications.
 * [graphql-strong](https://github.com/calebmer/graphql-strong) - Define your GraphQL schemas with confidence that your values are correct.
 * [graphql-to-typescript](https://github.com/3VLINC/graphql-to-typescript) - Compiles GraphQL files into an importable typescript module with type definitions
 * [graphql-decorator](https://github.com/Quramy/graphql-decorator) - Helps to build GraphQL schema with TypeScript.


### PR DESCRIPTION
changed GraphStack name since it was re-brended into "Vesper"

**[URL to the resource here.]**

**[Explain what this resource is all about and why it should be included here.]**
