### PR TITLE
Add graphql-cost-analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-disable-introspection](https://github.com/helfer/graphql-disable-introspection) - Graphql Disable Introspection
 * [mongo-graphql-starter](https://github.com/arackaf/mongo-graphql-starter) - Flexible and robust Mongo based resolvers for Node.
 * [altair-express-middleware](https://github.com/imolorhe/altair) - An express middleware for mounting an instance of Altair GraphQL client.
+* [graphql-cost-analysis](https://github.com/pa-bru/graphql-cost-analysis) - A Graphql query cost analyzer.
 
 ##### Relay Related
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/pa-bru/graphql-cost-analysis

**[Explain what this resource is all about and why it should be included here.]**
This resource analyzes the request content and computes its cost with your GraphQL server cost configuration.
This can be used to protect your GraphQL servers against DoS attacks, compute the data consumption per user and limit it.

