### PR TITLE
Add Digia's PHP7 GraphQL library

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [eZ Platform GraphQL Bundle](https://www.symfony.fi/entry/graphql-bundle-adds-protocol-support-to-ez-platform-symfony-cms) - GraphQL Bundle for the eZ Platform Symfony CMS.
 * [GraphQL Middleware](https://github.com/stefanorg/graphql-middleware) - GraphQL Psr7 Middleware
 * [Zend Expressive GraphiQL Extension](https://github.com/stefanorg/zend-expressive-graphiql) - GraphiQL extension for zend expressive
+* [GraphQL for PHP7](https://github.com/digiaonline/graphql-php) - A batteries-included, standard-compliant and easy to work with implementation of the GraphQL specification in PHP7 (based on the reference implementation).
 
 <a name="lib-py" />
 


### PR DESCRIPTION
[GraphQL for PHP7](https://github.com/digiaonline/graphql-php)

We have been working on a new implementation of the GraphQL specification for the past three months because none of the existing ones met our needs. 

Our implementation will allow developers to use features of the specification that are not available through any of the existing implementations.
