### PR TITLE
Add babel-plugin-inline-import-graphql-ast

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-disable-introspection](https://github.com/helfer/graphql-disable-introspection) - Graphql Disable Introspection
 * [mongo-graphql-starter](https://github.com/arackaf/mongo-graphql-starter) - Flexible and robust Mongo based resolvers for Node.
 * [altair-express-middleware](https://github.com/imolorhe/altair) - An express middleware for mounting an instance of Altair GraphQL client.
+* [babel-plugin-inline-import-graphql-ast](https://github.com/detrohutt/babel-plugin-inline-import-graphql-ast) - 
+A Babel plugin allowing import of .graphql and .gql files into javascript files.
 
 ##### Relay Related
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/detrohutt/babel-plugin-inline-import-graphql-ast

**[Explain what this resource is all about and why it should be included here.]**
My Babel plugin allows users to keep their GraphQL code in `.graphql` or `.gql` files, and then import one or more operations (or a fragment) from the GraphQL file to their javascript code, where it will have been parsed using `gql` from [`graphql-tag`](https://github.com/apollographql/graphql-tag), meaning it's ready for use with Apollo straight from the GraphQL file.

It has been included in the [documentation for `graphql-tag`](https://github.com/apollographql/graphql-tag#react-native-nextjs) and [Apollo](https://www.apollographql.com/docs/react/recipes/webpack.html#React-native) for quite a while now and has 25k downloads/month and no open issues (except me asking for help improving my README lol) so it's pretty stable. :)