### PR TITLE
Add go2gql tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [json-graphql-server](https://github.com/marmelab/json-graphql-server) - Get a full fake GraphQL API with zero coding in less than 30 seconds, based on a JSON data file.
 * [Insomnia](https://insomnia.rest/) – An full-featured API client with first-party GraphQL query editor
 * [RAN Toolkit](https://github.com/sly777/ran) - Production-ready toolkit/boilerplate with support for GraphQL, SSR, Hot-reload, CSS-in-JS, caching, and more.
+* [proto2gql](https://github.com/saturn4er/proto2gql) - [go-graphql](https://github.com/playlyfe/go-graphql) GraphQL Schema generator for .proto files
 
 <a name="databases" />
 


### PR DESCRIPTION
https://github.com/EGT-Ukraine/go2gql

The description of the scheme for graphql-go takes a long time, this tool generates it based on .proto  and swagger files. It is especially useful when developing API Gateways