### PR TITLE
Added new tool - GraphQL Documentation Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [json-graphql-server](https://github.com/marmelab/json-graphql-server) - Get a full fake GraphQL API with zero coding in less than 30 seconds, based on a JSON data file.
 * [Insomnia](https://insomnia.rest/) – An full-featured API client with first-party GraphQL query editor
 * [RAN Toolkit](https://github.com/sly777/ran) - Production-ready toolkit/boilerplate with support for GraphQL, SSR, Hot-reload, CSS-in-JS, caching, and more.
+* [GraphQL Documentation Generator](https://graphqldoc.com/) - Generate documentation for any GraphQL endpoint based on it's URL or the Introspection response. 
 
 <a name="databases" />
 


### PR DESCRIPTION
- https://graphqldoc.com/
- https://github.com/dhruv-kumar-jha/graphql-doc

This tool allows user to generate documentation for any available GraphQL server based on it's endpoint or the Introspection Response.