### PR TITLE
Add reference to graphql-resolvers-xray-tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-lodash](https://github.com/APIs-guru/graphql-lodash) - Data manipulation for GraphQL queries with lodash syntax.
 * [apollo-angular](https://github.com/apollographql/apollo-angular) - Angular integration for Apollo.
 * [graphql-resolvers](https://github.com/lucasconstantino/graphql-resolvers) - Resolver composition library for GraphQL.
+* [graphql-resolvers-xray-tracing](https://github.com/lifeomic/graphql-resolvers-xray-tracing) - A GraphQL middleware to enable X-Ray tracing subsegments for GraphQL resolvers.
 * [apollo-resolvers](https://github.com/thebigredgeek/apollo-resolvers) - Expressive and composable resolvers for Apollo Server and graphql-tools.
 * [apollo-errors](https://github.com/thebigredgeek/apollo-errors) - Machine-readable custom errors for Apollo Server.
 * [graphql-disable-introspection](https://github.com/helfer/graphql-disable-introspection) - Graphql Disable Introspection


### PR DESCRIPTION
https://github.com/lifeomic/graphql-resolvers-xray-tracing

Debugging performance issues associated with GraphQL resovlers can be had to do in a deployment, and this library allows you to easily see the time breakdown using AWS X-Ray
