### PR TITLE
Added nodes to Java section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [rdbms-to-graphql](https://github.com/ebridges/rdbms-to-graphql) - A Java CLI program that generates a GraphQL schema from a JDBC data source.
 * [Rejoiner](https://github.com/google/rejoiner) - Generates a GraphQL schema based on one or more gRPC microservices, or any other Protobuf source.
 * [graphql-spqr](https://github.com/leangen/graphql-spqr) - GraphQL SPQR aims to make it dead simple to add a GraphQL API to any Java project. It works by dynamically generating a GraphQL schema from Java code.
+* [nodes](https://github.com/americanexpress/nodes) - A GraphQL JVM Client designed for constructing queries from standard model definitions.
 
 <a name="lib-c" />
 


### PR DESCRIPTION
https://github.com/americanexpress/nodes

GraphQL is supported by many different programming languages for server-side implementations; however the number of client libraries is limited. Most of these client libraries are designed to make it easy to build UI components that fetch data with GraphQL. There is no prevailing client library to invoke GraphQL endpoints using Java. Nodes fixes this: a GraphQL client that is suitable for any JVM environment. It is designed for Java engineers with a desire to use GraphQL APIs in a familiar way – a simple, flexible, compatible, adoptable, understandable library for everyone! https://americanexpress.io/graphql-for-the-jvm/
