### PR TITLE
Add GraphQL Manchester meetup

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Dallas-Fort Worth](https://www.meetup.com/DFW-GraphQL-Meetup/)
 * [Istanbul](https://www.meetup.com/GraphQL-Istanbul/)
 * [London](https://www.meetup.com/GraphQL-London/)
+* [Manchester](https://www.meetup.com/GraphQL-Manchester/)
 * [Melbourne](https://www.meetup.com/GraphQL-Melbourne/)
 * [Munich](https://www.meetup.com/GraphQL-Munich/)
 * [New York City](https://www.meetup.com/GraphQL-NYC/)


### PR DESCRIPTION
https://www.meetup.com/GraphQL-Manchester/

There's a new GraphQL meetup in Manchester. We've had 2 meetups so far and it would be great if it could be included in this list
