### PR TITLE
Add areas for Books witrh Fullstack GraphQL, The GraphQL Guide, and Craft GraphQL APIs in Elixir with Absinthe

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Blogs](#blogs)
 - [Posts](#post)
 - [Workshoppers](#workshopper)
+- [Books](#books)
 
 <!-- /MarkdownTOC -->
 
@@ -655,6 +656,14 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [learning-graphql](https://github.com/mugli/learning-graphql) - An attempt to learn GraphQL.
 * [Learn Relay](https://www.learnrelay.org/) - A comprehensive introduction to Relay
 * [Learn Apollo](https://www.learnapollo.com/) - A hands-on tutorial for Apollo GraphQL Client
+
+<a name="books" />
+
+## Books
+
+* [Fullstack GraphQL](https://www.graphql.college/fullstack-graphql) - Open source book on GraphQL in Node, Apollo GraphQL, and React
+* [The GraphQL Guide](https://graphql.guide/) - Learn full stack GraphQL across several platforms from John Resig (creator of JQuery) and Loren Sands-Ramshaw
+* [Creaft GraphQL APIs in Elixir with Absinthe](https://pragprog.com/book/wwgraphql/craft-graphql-apis-in-elixir-with-absinthe) - Written by the creators of Absinthe, this book will help you take full advantage of these two groundbreaking technologies. This book is also included in the Safari books subscription service.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -663,7 +663,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 
 * [Fullstack GraphQL](https://www.graphql.college/fullstack-graphql) - Open source book on GraphQL in Node, Apollo GraphQL, and React
 * [The GraphQL Guide](https://graphql.guide/) - Learn full stack GraphQL across several platforms from John Resig (creator of JQuery) and Loren Sands-Ramshaw
-* [Creaft GraphQL APIs in Elixir with Absinthe](https://pragprog.com/book/wwgraphql/craft-graphql-apis-in-elixir-with-absinthe) - Written by the creators of Absinthe, this book will help you take full advantage of these two groundbreaking technologies. This book is also included in the Safari books subscription service.
+* [Craft GraphQL APIs in Elixir with Absinthe](https://pragprog.com/book/wwgraphql/craft-graphql-apis-in-elixir-with-absinthe) - Written by the creators of Absinthe, this book will help you take full advantage of these two groundbreaking technologies. This book is also included in the Safari books subscription service.
 
 ## License
 


### PR DESCRIPTION
Add some books to the list!

* [Fullstack GraphQL](https://www.graphql.college/fullstack-graphql) - Open source book on GraphQL in Node, Apollo GraphQL, and React
* [The GraphQL Guide](https://graphql.guide/) - Learn full stack GraphQL across several platforms from John Resig (creator of JQuery) and Loren Sands-Ramshaw
* [Craft GraphQL APIs in Elixir with Absinthe](https://pragprog.com/book/wwgraphql/craft-graphql-apis-in-elixir-with-absinthe) - Written by the creators of Absinthe, this book will help you take full advantage of these two groundbreaking technologies. This book is also included in the Safari books subscription service.

Why?
Because books are awesome too!