### PR TITLE
Add the Rust graphql-client crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Rust Libraries
 
 * [juniper](https://github.com/mhallin/juniper) - GraphQL server library for Rust.
+* [graphql-client](https://github.com/tomhoule/graphql-client) - GraphQL client library for Rust with WebAssembly (wasm) support.
 
 <a name="lib-r" />
 


### PR DESCRIPTION
[Link to the project](https://github.com/tomhoule/graphql-client)

This is currently the only Rust GraphQL client, it is actively developed and has nice features like webassembly support.