### PR TITLE
Add the Rust graphql-parser crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [juniper](https://github.com/mhallin/juniper) - GraphQL server library for Rust.
 * [graphql-client](https://github.com/tomhoule/graphql-client) - GraphQL client library for Rust with WebAssembly (wasm) support.
+* [graphql-parser](https://github.com/graphql-rust/graphql-parser) - A parser, formatter and AST for the GraphQL query and schema definition language for Rust.
 
 <a name="lib-r" />
 


### PR DESCRIPTION
url: https://github.com/graphql-rust/graphql-parser

It is used by other libraries including graphql-client and supports the
most recent version of the spec (june 2018).