### PR TITLE
Add graphql-cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-batch](https://github.com/Shopify/graphql-batch) - A query batching executor for the graphql gem.
 * [batch-loader](https://github.com/exaspark/batch-loader) – A powerful tool to avoid N+1 queries without extra dependencies or primitives.
 * [graphql-guard](https://github.com/exAspArk/graphql-guard) - A simple field-level authorization for the graphql gem.
+* [graphql-cache](https://github.com/stackshareio/graphql-cache) - A dead simple caching plugin for graphql-ruby.
 
 <a name="lib-php" />
 


### PR DESCRIPTION
**[The blog post](https://stackshare.io/posts/introducing-graphql-cache)** and **[the GitHub project](https://github.com/stackshareio/graphql-cache)**

After using graphql-ruby for a while, we realized it was missing an easy way to cache resolved fields.

So we built one. 😎