### PR TITLE
Add graphql-pynamodb to Python list

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [python-graphql-client](https://github.com/graphcool/python-graphql-client) - Simple GraphQL client for Python 2.7+
 * [python-graphjoiner](https://github.com/healx/python-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.
 * [graphene-django](https://github.com/graphql-python/graphene-django) - A Django integration for Graphene.
+* [graphql-pynamodb](https://github.com/yfilali/graphql-pynamodb) - A PynamoDB integration for Graphene.
 
 <a name="lib-java" />
 


### PR DESCRIPTION
**[https://github.com/yfilali/graphql-pynamodb]**

**[A PynamoDB (a pythonic interface to Amazon's DynamoDB) integration for Graphene.]**
