### PR TITLE
Add swagger-graphene library as python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 ### Python Examples
 
 * [swapi-graphene](https://github.com/graphql-python/swapi-graphene) - A GraphQL schema and server using [Graphene](http://graphene-python.org) - [View demo online](http://swapi.graphene-python.org).
+* [swagger-graphene](https://github.com/amritajain/swagger-graphene) - A GraphQL library to convert Swagger schema into dynamic Graphene models and deployed using serverless framework. 
 
 <a name="example-elixir" />
 


### PR DESCRIPTION
**[https://github.com/amritajain/swagger-graphene]**

**[A GraphQL library to convert Swagger schema into dynamic Graphene models and deployed using Serverless framework. Includes best practices for python and serverless while building graphene libraries.]**
