### PR TITLE
Added post to a schema stitching guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [Sharing data in a Microservices Architecture using GraphQL](https://labs.getninjas.com.br/sharing-data-in-a-microservices-architecture-using-graphql-97db59357602)
 * [Let's build a node.js GraphQL server for fetching Spotify REST API, in German](https://blog.codecentric.de/2017/09/graphql-mit-spotify-teil-1-server/) |  [in English](https://blog.codecentric.de/en/2017/01/lets-build-spotify-graphql-server/)
 * [“Client-side only” realtime web applications with Firebase, GraphQL and apollo-client 2.0](https://medium.com/@pierrecriulanscy/client-side-only-realtime-web-applications-with-firebase-graphql-and-apollo-client-2-0-9606160f7cf8)
+* [Ultimate Guide To Schema Stitching in GraphQL](https://blog.hasura.io/the-ultimate-guide-to-schema-stitching-in-graphql-f30178ac0072)
 
 <a name="books" />
 

--- a/README.md
+++ b/README.md
@@ -672,7 +672,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [Sharing data in a Microservices Architecture using GraphQL](https://labs.getninjas.com.br/sharing-data-in-a-microservices-architecture-using-graphql-97db59357602)
 * [Let's build a node.js GraphQL server for fetching Spotify REST API, in German](https://blog.codecentric.de/2017/09/graphql-mit-spotify-teil-1-server/) |  [in English](https://blog.codecentric.de/en/2017/01/lets-build-spotify-graphql-server/)
 * [“Client-side only” realtime web applications with Firebase, GraphQL and apollo-client 2.0](https://medium.com/@pierrecriulanscy/client-side-only-realtime-web-applications-with-firebase-graphql-and-apollo-client-2-0-9606160f7cf8)
-* [Ultimate Guide To Schema Stitching in GraphQL](https://blog.hasura.io/the-ultimate-guide-to-schema-stitching-in-graphql-f30178ac0072)
+* [Ultimate Guide To Schema Stitching in GraphQL](https://medium.com/m/global-identity?redirectUrl=https%3A%2F%2Fblog.hasura.io%2Fthe-ultimate-guide-to-schema-stitching-in-graphql-f30178ac0072)
 
 <a name="books" />
 


### PR DESCRIPTION
[Ultimate Guide To Schema Stitching in GraphQL](https://blog.hasura.io/the-ultimate-guide-to-schema-stitching-in-graphql-f30178ac0072)

The ressource shows how to stitch a schema using the graphql tools by apollo. Because there is no other guide for that topic I think that this should be included. Also it is not easy to find on google. 