### PR TITLE
ADD generic Graphql API to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphqlviz](https://github.com/sheerun/graphqlviz) - GraphQL API visualizer in Node.js
 * [Graphql for VSCode](https://github.com/kumarharsh/graphql-for-vscode) - VSCode extension for GraphQL schema authoring & consumption. Uses the language server protocol to provide first-class editing capabilities for graphql devs.
 * [Relay Playground](http://facebook.github.io/relay/prototyping/playground.html)
+* [GraphQL Proxy API](https://github.com/fasibio/GraphqlDockerProxy) - A generic Graphql API (Docker & Kubernetes). Compare your GraphQL Microservices without code into one API
 * [GraphQL AST Explorer](http://dferber90.github.io/graphql-ast-explorer/) - Explore the AST of a GraphQL document interactively
 * [GraphQLHub](https://www.graphqlhub.com/) - Query public API's schemas (e.g. Reddit, Twitter, Github, etc) using GraphiQL
 * [js-graphql-intellij-plugin](https://github.com/jimkyndemeyer/js-graphql-intellij-plugin/) - GraphQL language support for IntelliJ IDEA and WebStorm, including Relay.QL tagged templates in JavaScript and TypeScript.


### PR DESCRIPTION
A generic Graphql API (Docker & Kubernetes). Compare your GraphQL Microservices without extra code.

https://github.com/fasibio/GraphqlDockerProxy

Its a  Dockercontainer which is a generic GraphQL API Gateway. 
It watch your orchestrator and add the GraphQL Microservices. 
The configuration is full at the GraphQL Microservices. 
You does not need configure your API. 
Look here ![kontext](https://raw.githubusercontent.com/fasibio/GraphqlDockerProxy/master/doc/assets/kontext.png)
