### PR TITLE
add graphql-middleware to list of js libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-cost-analysis](https://github.com/pa-bru/graphql-cost-analysis) - A Graphql query cost analyzer.
 * [gql](https://github.com/Mayank1791989/gql) - Graphql sevice which watches project files and provides validation, autocompletion, get defintion, etc. for GraphQL schema and queries. Works with Relay classic, Relay modern and Apollo, as well as embedded GraphQL queries within any other language such as JS, Golang, Ruby, Cucumber test files, etc.
 * [gql-language-server](https://github.com/Mayank1791989/gql-language-server) - A language-server implementation on top of the [gql](https://github.com/Mayank1791989/gql) library.
+* [graphql-middleware](https://github.com/prisma/graphql-middleware/) - Split up your GraphQL resolvers in middleware functions.
 
 ##### Relay Related
 


### PR DESCRIPTION
https://github.com/prisma/graphql-middleware/

This library is useful to add common logic for resolvers, without having to pollute the resolvers with this logic