### PR TITLE
move f/graphql.js to clients.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [micro-graphql-react](https://github.com/arackaf/micro-graphql-react) - A lighweight utility for adding GraphQL to React. components. Includes simple caching and uses GET requests that could additionally be cached through a service-worker. 
 * [Lokka](https://github.com/kadirahq/lokka) - Simple JavaScript client for GraphQL, which you can use anywhere.
 * [react-reach](https://github.com/kennetpostigo/react-reach) - A library to communicate with Graphql through Redux.
+* [graphql.js](https://github.com/f/graphql.js) - A Simple and Isomorphic GraphQL Client for JavaScript
 
 ##### Miscellaneous 
 
@@ -159,7 +160,6 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphiteJS](https://github.com/graphitejs/graphitejs) - Full stack GraphQL framework.
 * [loopback-graphql](https://github.com/tallyb/loopback-graphql) - GraphQL Server for Loopback.
 * [parasprite](https://github.com/octet-stream/parasprite) - Describe your GraphQL schema using chainable interface.
-* [GraphQL.js](https://github.com/f/graphql.js) - JavaScript GraphQL Client for Browser and Node.js Usage
 * [graphql-sync](https://github.com/arangodb/graphql-sync) - Promise-free wrapper to GraphQL.js for synchronous environments
 * [Spikenail](https://github.com/spikenail/spikenail) - Node.js framework for building GraphQL API almost without coding.
 * [graphql-weaver](https://github.com/AEB-labs/graphql-weaver) - A tool to combine, link and transform GraphQL schemas; combine multiple GraphQL servers into one API.


### PR DESCRIPTION
Since https://github.com/f/graphql.js is a GraphQL client, it needs to be moved to clients part.

https://github.com/f/graphql.js

It's a simple and lightweight (zero-dependency) graphql client works with browser and node.
