### PR TITLE
Add Hamburg to list of GraphQL meetups

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Berlin](https://www.meetup.com/graphql-berlin/)
 * [Buenos Aires](https://www.meetup.com/es-ES/GraphQL-BA/)
 * [Dallas-Fort Worth](https://www.meetup.com/DFW-GraphQL-Meetup/)
+* [Hamburg](https://www.meetup.com/GraphQL-Hamburg/)
 * [Istanbul](https://www.meetup.com/GraphQL-Istanbul/)
 * [London](https://www.meetup.com/GraphQL-London/)
 * [Manchester](https://www.meetup.com/GraphQL-Manchester/)


### PR DESCRIPTION
**https://www.meetup.com/GraphQL-Hamburg/**

**Hamburg is the biggest non-capital city in Europe and regularily hosts a fantastic GraphQL Meetup organised by @skorfmann.**