### PR TITLE
Add Saleor to the Services list

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Scaphold](https://scaphold.io/) - GraphQL as a service that includes API integrations such as Stripe and Mailgun.
 * [Tipe](https://tipe.io/) - Next Generation API-first CMS with a GraphQL or REST API. Stop letting your CMS decide how you build your apps.
 * [AWS AppSync](https://aws.amazon.com/appsync/) - Serverless GraphQL
+* [Saleor](https://github.com/mirumee/saleor/) - GraphQL-first headless e-commerce platform.
 
 <a name="example" />
 


### PR DESCRIPTION
This PR adds Saleor to the Services list.

https://github.com/mirumee/saleor/

Saleor is an open-source, GraphQL-first headless e-commerce platform. It comes with a single-page management dashboard and an example PWA storefront.
Public API demo: https://demo.getsaleor.com/graphql/
