### PR TITLE
Added Cloud CMS (GraphQL CMS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Scaphold](https://scaphold.io/) - GraphQL as a service that includes API integrations such as Stripe and Mailgun.
 * [Tipe](https://tipe.io/) - Next Generation API-first CMS with a GraphQL or REST API. Stop letting your CMS decide how you build your apps.
 * [AWS AppSync](https://aws.amazon.com/appsync/) - Serverless GraphQL
+* [Cloud CMS](https://www.cloudcms.com/documentation/graphql.html) - GraphQL CMS that offers Git-like changeset versioning, branches, query, full-text search, sorting, pagination and a lot more.
 
 <a name="example" />
 


### PR DESCRIPTION
Added an entry for Cloud CMS.

Cloud CMS offers GraphQL support as part of its larger API.  It also offers a full editorial environment, publishing, deployment, branching and a wide array of enterprise capabilities that are ideal for CMS editorial teams and developers.

https://www.cloudcms.com
https://www.cloudcms.com/documentation/graphql.html