### PR TITLE
Adding The Guild's blog to blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 ## Blogs
 * [Official GraphQL blog](http://graphql.org/blog/)
 * [Building Apollo](https://medium.com/apollo-stack)
+* [The Guild blog](https://medium.com/the-guild)
 
 <a name="post" />
 


### PR DESCRIPTION
**[https://medium.com/the-guild]**

**[The Guild is a group of open source developers focusing on building open source GraphQL libraries. this blog is where we share news about GraphQL, our libraries, updates we do and best practices of using GraphQL]**
