### PR TITLE
Remove dead graphql-ruby-relay link

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Ruby Libraries
 
 * [graphql-ruby](https://github.com/rmosolgo/graphql-ruby) - Ruby implementation of Facebook's GraphQL.
-* [graphql-relay-ruby](https://github.com/rmosolgo/graphql-relay-ruby) - Relay helpers for GraphQL & Ruby.
 * [graphql-parser](https://github.com/Shopify/graphql-parser) - A small ruby gem wrapping the libgraphqlparser C library for parsing GraphQL.
 * [graphql-client](https://github.com/github/graphql-client) - A Ruby library for declaring, composing and executing GraphQL queries.
 * [graphql-batch](https://github.com/Shopify/graphql-batch) - A query batching executor for the graphql gem.


### PR DESCRIPTION
https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md#breaking-changes-35

The link for graphql-relay-ruby is dead. graphql-relay-ruby (rubygem: graphql-relay) was merged into graphql-ruby
