### PR TITLE
GraphQL Inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [RAN Toolkit](https://github.com/sly777/ran) - Production-ready toolkit/boilerplate with support for GraphQL, SSR, Hot-reload, CSS-in-JS, caching, and more.
 * [Apollo GraphQL VSCode Extension](https://marketplace.visualstudio.com/items?itemName=apollographql.vscode-apollo) - Rich editor support for GraphQL client and server development that seamlessly integrates with the Apollo platform
 * [GRAPHQL DESIGNER](http://graphqldesigner.com/) - A developer's web-app tool to rapidly prototype a full stack CRUD implementation of GraphQL with React.
+* [GraphQL Inspector](https://graphql-inspector.com/) - Tooling for GraphQL. Compare schemas, validate documents, find breaking changes, find similar types, schema coverage.
 
 <a name="databases" />
 


### PR DESCRIPTION
[GraphQL Inspector - website](https://graphql-inspector.com)

Prevent breaking changes. Find broken operations. Get Schema Coverage. Check deprecated usage and type duplicates. All as part of your CI process.

GraphQL Inspector is a Github App but could be used as a Github Action or might be self-hosted.

