### PR TITLE
Split out JavaScript "HTTP Server Bindings" from "Miscellaneous" section.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ before_script:
   - gem install awesome_bot
 script:
   - git diff master.. -U0 README.md | grep -Po "(?<=^\+).*" >> temp.md
-  - awesome_bot README.md --white-list medium,jacobwgillespie,wehavefaces,graphql,slack,vimeo,slideshare,julienvincent
+  - awesome_bot README.md --white-list medium,jacobwgillespie,wehavefaces,graphql,slack,vimeo,slideshare,julienvincent,meetup

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 #### Clients
 * [relay](https://github.com/facebook/relay) - Relay is a JavaScript framework for building data-driven React applications.
-* [Apollo Client](https://github.com/apollographql/apollo-client) - A well-documented GraphQL client. Has React and Angular bindings.
+* [Apollo Client](https://github.com/apollographql/apollo-client) - A fully-featured, production ready caching GraphQL client for every UI framework and GraphQL server.
 * [aws-amplify](https://github.com/aws-amplify/amplify-js) - A client library developed by Amazon for caching, analytics and more that includes a way to fetch GraphQL queries.
 * [graphql-request](https://github.com/prismagraphql/graphql-request) - A minimal GraphQL client for Node and browsers.
 * [FetchQL](https://github.com/gucheen/FetchQL) - A simple GraphQL query client using Fetch.
@@ -137,7 +137,6 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraysQL](https://github.com/larsbs/graysql) - A GraphQL manager and loader.
 * [graysql-orm-loader](https://github.com/larsbs/graysql-orm-loader) - A GraysQL extension to load a GraphQL schema from an ORM.
 * [Annotated GraphQL](https://github.com/almilo/annotated-graphql) - Proof of Concept for annotations in GraphQL (i.e.: transform an existing REST api into a GraphQL endpoint).
-* [Apollo Client](https://github.com/apollographql/apollo-client) - A well-documented GraphQL client that integrates with Redux. Has React and Angular bindings.
 * [graphql-tools](https://github.com/apollostack/graphql-tools) - Tool library for building and maintaining GraphQL-JS servers.
 * [graphql-anywhere](https://github.com/apollostack/graphql-anywhere) - Run a GraphQL query anywhere, against any data, with no schema.
 * [graphql-tag](https://github.com/apollostack/graphql-tag) - A JavaScript template literal tag that parses GraphQL queries.

--- a/README.md
+++ b/README.md
@@ -114,13 +114,15 @@ If you want to contribute to this list (please do), send me a pull request.
 * [react-reach](https://github.com/kennetpostigo/react-reach) - A library to communicate with Graphql through Redux.
 * [Grafoo](https://github.com/grafoojs/grafoo) - A tiny yet fully fledged cache based GraphQL client
 
+#### HTTP Server Bindings
+* [express-graphql](https://github.com/graphql/express-graphql) - GraphQL Express Middleware.
+* [hapi-graphql](https://github.com/SimonDegraeve/hapi-graphql) - Create a GraphQL HTTP server with Hapi.
+* [hapi-plugin-graphiql](https://github.com/rse/hapi-plugin-graphiql) - HAPI plugin for GraphiQL integration.
+* [koa-graphql](https://github.com/chentsulin/koa-graphql) - GraphQL Koa Middleware.
+
 #### Miscellaneous
 
 * [GraphQL.js](https://github.com/graphql/graphql-js) - A reference implementation of GraphQL for JavaScript.
-* [express-graphql](https://github.com/graphql/express-graphql) - GraphQL Express Middleware.
-* [koa-graphql](https://github.com/chentsulin/koa-graphql) - GraphQL Koa Middleware.
-* [hapi-graphql](https://github.com/SimonDegraeve/hapi-graphql) - Create a GraphQL HTTP server with Hapi.
-* [hapi-plugin-graphiql](https://github.com/rse/hapi-plugin-graphiql) - HAPI plugin for GraphiQL integration.
 * [codemirror-graphql](https://github.com/graphql/codemirror-graphql) - GraphQL mode and helpers for CodeMirror.
 * [graphql-schema](https://github.com/devknoll/graphql-schema) - Create GraphQL schemas with a fluent/chainable interface.
 * [graphql-sequelize](https://github.com/mickhansen/graphql-sequelize) - Sequelize helpers for GraphQL.


### PR DESCRIPTION
This is the first of several iterations in an attempt to segment the list of links under `Miscellaneous`. This iteration creates a new `HTTP Server Bindings` section in the `JavaScript Libraries` section between the `Clients` and `Miscellaneous` sub-sections.

This fixes (or rather, starts down the path of fixing) #200.
