### PR TITLE
Run awesome_bot on all links again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - git diff master.. -U0 README.md | grep -Po "(?<=^\+).*" >> temp.md
-  - awesome_bot temp.md --allow-ssl --allow-redirect --white-list medium,jacobwgillespie,wehavefaces,graphql,slack,vimeo,slideshare,julienvincent,meetup
+  - awesome_bot README.md --allow-ssl --allow-redirect --white-list medium,jacobwgillespie,wehavefaces,graphql,slack,vimeo,slideshare,julienvincent,meetup


### PR DESCRIPTION
The command for copying over only the changed links to temp.md is not working and causing CI to fail. This removes it and runs awesome_bot on all links, but with new flags that are more lenient.