### PR TITLE
Added reasonml libraries.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ If you want to contribute to this list (please do), send me a pull request.
 	- [Android](#lib-android)
 	- [iOS](#lib-ios)
 	- [ClojureScript](#lib-clojurescript)
+	- [ReasonML](#lib-reasonml)
 - [Tools](#tools)
 - [Services](#services)
 - [Databases](#databases)
@@ -357,6 +358,13 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [re-graph](https://github.com/oliyh/re-graph) - A GraphQL client for ClojureScript with bindings for re-frame applications.
 * [graphql-query](https://github.com/district0x/graphql-query) - Clojure(Script) GraphQL query generation.
+
+<a name="lib-reasonml" />
+
+### ReasonML Libraries
+
+* [reason-apollo](https://github.com/apollographql/reason-apollo) - ReasonML binding for Apollo Client
+* [ReasonQL](https://github.com/sainthkh/reasonql) - Type-safe and simple GraphQL Client for ReasonML developers.
 
 <a name="tools" />
 


### PR DESCRIPTION
## Links
reason-apollo: https://github.com/apollographql/reason-apollo
ReasonQL: https://github.com/sainthkh/reasonql

## Why
1. There is no reasonml libraries in the list. 
2. reason-apollo is the binding of the famous Apollo Client. I think it's worth a place because of that. And ReasonQL is the type-safe and simple library. It fetches JSON data from GraphQL server and decodes them to ReasonML records. 

**DISCLAIMER:** I'm the developer of ReasonQL. 
