### PR TITLE
Update elm-graphql link

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 ### Elm Libraries
 
-* [elm-graphql](https://github.com/jahewson/elm-graphql) - GraphQL for Elm.
+* [elm-graphql](https://github.com/dillonkearns/elm-graphql) - GraphQL for Elm.
 
 <a name="lib-clojure" />
 


### PR DESCRIPTION
`elm-graphql` currently links to [**jahewson/elm-graphql**](https://github.com/jahewson/elm-graphql), which is unmaintained and has not been updated in 3 years.

Changed to [**dillonkearns/elm-graphql**](https://github.com/dillonkearns/elm-graphql), which is actively maintained, and the most popular implementation I'm aware of!