### PR TITLE
Add graphql-api-koa to the HTTP Server Bindings list

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [express-graphql](https://github.com/graphql/express-graphql) - GraphQL Express Middleware.
 * [hapi-graphql](https://github.com/SimonDegraeve/hapi-graphql) - Create a GraphQL HTTP server with Hapi.
 * [hapi-plugin-graphiql](https://github.com/rse/hapi-plugin-graphiql) - HAPI plugin for GraphiQL integration.
+* [graphql-api-koa](https://github.com/jaydenseric/graphql-api-koa) - GraphQL Koa middleware that implements GraphQL.js from scratch and supports native ESM.
 * [koa-graphql](https://github.com/chentsulin/koa-graphql) - GraphQL Koa Middleware.
 
 #### Database & ORM


### PR DESCRIPTION
https://github.com/jaydenseric/graphql-api-koa

[`graphql-api-koa`](https://github.com/jaydenseric/graphql-api-koa) is a GraphQL.js implementation written from scratch for Koa. It is the only such alternative to [`apollo-server-koa`](https://npm.im/apollo-server-koa) as [`koa-graphql`](https://npm.im/koa-graphql) just wraps [`express-graphql`](https://npm.im/express-graphql).

Uniquely, it's separate [`errorHandler()`](https://github.com/jaydenseric/graphql-api-koa#function-errorhandler) and [`execute()`](https://github.com/jaydenseric/graphql-api-koa#function-execute) middlewares allow Koa "onion" style error handling; middleware errors result in an appropriate GraphQL response with errors.

With a [96.5kb install size](https://packagephobia.now.sh/result?p=graphql-api-koa) and a [3.2kb min+gzip bundle size](https://bundlephobia.com/result?p=graphql-api-koa), it is to my knowledge the lightest Node.js GraphQL server available. For comparison, [`apollo-server-koa` has an 11.8M install size](https://packagephobia.now.sh/result?p=apollo-server-koa) and [`koa-graphql` has a 3.03M install size](https://packagephobia.now.sh/result?p=koa-graphql).

The cherry on top is that it is the only GraphQL server to support native ESM for Node.js in `--experimental-modules` mode.

I've been using it in production for several APIs.