### PR TITLE
Add GraphQL Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphQL APIs](https://github.com/APIs-guru/graphql-apis) - A collective list of public GraphQL APIs
 * [GraphQL World](https://graphql-world.com) - The fastest growing community of GraphQL developers
 * [/r/GraphQL](https://old.reddit.com/r/graphql/) - A Subreddit for interesting and informative GraphQL content and discussions.
+* [GraphQL Jobs](https://graphql.jobs) - A list of GraphQL-based jobs in startups all over the world.
 
 <a name="meetups" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://graphql.jobs

**[Explain what this resource is all about and why it should be included here.]**
GraphQL jobs is a community-curated GraphQL-related job listings. Posting a job is free, as long as the job includes working with GraphQL directly. It is still not easy to find companies that work with GraphQL (especially outside SF and Berlin). The goal here is to make it easier.