### PR TITLE
Added SwitchQL to tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,7 @@ for the Angel framework.
 * [GraphQL Inspector](https://graphql-inspector.com/) - Tooling for GraphQL. Compare schemas, validate documents, find breaking changes, find similar types, schema coverage.
 * [graphql-typed-client](https://github.com/helios1138/graphql-typed-client) - A tool that generates a strongly typed client library for any GraphQL endpoint.  The client allows writing GraphQL queries as plain JS objects (with type safety and awesome code completion experience)
 * [OASGraph](https://github.com/strongloop/oasgraph) - Take any OpenAPI Specification (OAS) or swagger and create a GraphQL interface - One minute video and resources [here](https://v4.loopback.io/oasgraph.html)
+* [SwitchQL](https://github.com/SwitchQL/SwitchQL) - Automated transcription of database schemas into GraphQL schemas, resolvers, queries, and mutations
 
 <a name="databases" />
 


### PR DESCRIPTION
https://github.com/SwitchQL/SwitchQL

SwitchQL automates the transcription of database schemas into GraphQL schemas, resolvers, queries, and mutations. Due to the security concerns when connecting to databases, the electron desktop application allows for use of the tool within a user's network or VPC.

We see this tool as helping new graphql users form a better understanding of graphql, but we also see potential for developers and companies to integrate this tool into a CI/CD pipeline or assist in a migration to graphql.

If you have any questions please feel free to reach out - laueian@gmail.com. Thanks!