### PR TITLE
Add bookmarks.dev to Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphQL World](https://graphql-world.com) - The fastest growing community of GraphQL developers
 * [/r/GraphQL](https://old.reddit.com/r/graphql/) - A Subreddit for interesting and informative GraphQL content and discussions.
 * [GraphQL Jobs](https://graphql.jobs) - A list of GraphQL-based jobs in startups all over the world.
+* [Bookmarks.dev](https://www.bookmarks.dev/search?q=graphql) - Dev bookmarks. Use the tag [graphql](https://www.bookmarks.dev/tagged/graphql)
 
 <a name="meetups" />
 


### PR DESCRIPTION
**[https://www.bookmarks.dev/]**

**[This resource is about managing your dev bookmarks and sharing the ones the community will profit from. You can easily find graphql related resources either by using graphql or the tag [graphql] in the search box. You can choose to follow the graphql tag to get the newest entries]**
