### PR TITLE
add Rust libraries back

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ If you want to contribute to this list (please do), send me a pull request.
 	- [ClojureScript](#lib-clojurescript)
 	- [ReasonML](#lib-reasonml)
 	- [Dart](#lib-dart)
+	- [Rust](#lib-rust)
 - [Tools](#tools)
 - [Services](#services)
 - [Databases](#databases)
@@ -379,6 +380,14 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Angel GraphQL](https://github.com/angel-dart/graphql) - GraphQL server implementation with bindings
 for the Angel framework.
 * [graphql-flutter](https://github.com/zino-app/graphql-flutter) - A GraphQL client for Flutter.
+
+<a name="lib-rust" />
+
+### Rust Libraries
+
+* [juniper](https://github.com/mhallin/juniper) - GraphQL server library for Rust.
+* [graphql-client](https://github.com/tomhoule/graphql-client) - GraphQL client library for Rust with WebAssembly (wasm) support.
+* [graphql-parser](https://github.com/graphql-rust/graphql-parser) - A parser, formatter and AST for the GraphQL query and schema definition language for Rust.
 
 <a name="tools" />
 


### PR DESCRIPTION
hi folx! :smiley_cat: 

as far as i can tell, it seems that https://github.com/chentsulin/awesome-graphql/pull/416 reverted a [merge commit](https://github.com/chentsulin/awesome-graphql/commit/0134f1fafd9e238b1afe5f47f1f932ce4dd99ad0), so anything that was added within the time frame of the merge commit (between Jan 5, 2017 and Dec 17, 2018?) was reverted.

this adds the changes from the following pull requests back in: https://github.com/chentsulin/awesome-graphql/pull/163, https://github.com/chentsulin/awesome-graphql/pull/365, and https://github.com/chentsulin/awesome-graphql/pull/366