### PR TITLE
link to FaunaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ for the Angel framework.
 
 * [Dgraph](https://dgraph.io/) - Scalable, distributed, low latency, high throughput Graph database with GraphQL as the query language
 * [EdgeDB](https://edgedb.com/) - The next generation object-relational database with native GraphQL support.
+* [FaunaDB](https://fauna.com) - Relational NoSQL database with [GraphQL schema import.](https://fauna.com/blog/getting-started-with-graphql-part-1-importing-and-querying-your-schema) Supports joins, indexes, and multi-region ACID transactions with serverless per-per-use pricing.
 
 <a name="services" />
 


### PR DESCRIPTION
Also includes link to GraphQL tutorial

[FaunaDB](https://fauna.com)

Fauna is a cloud database with native GraphQL support.
