### PR TITLE
Add go-graphql-subscription-example to go examples list

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 
 * [golang-relay-starter-kit](https://github.com/sogko/golang-relay-starter-kit) - Barebones starting point for a Relay application with Golang GraphQL server.
 * [todomvc-relay-go](https://github.com/sogko/todomvc-relay-go) - Port of the React/Relay TodoMVC app, driven by a Golang GraphQL backend.
+* [go-graphql-subscription-example](https://github.com/ccamel/go-graphql-subscription-example) - A GraphQL schema and server that demonstrates GraphQL [subscriptions](https://github.com/apollographql/subscriptions-transport-ws/blob/v0.9.4/PROTOCOL.md) (over Websocket) to consume [Apache Kafka](https://kafka.apache.org/) messages.
 
 <a name="example-scala" />
 


### PR DESCRIPTION
**https://github.com/ccamel/go-graphql-subscription-example**

The project shows the implementation of a simple GraphQL service allowing clients to consume messages from a kafka topic through a graphQL subscription endpoint.

This particular example demonstrates how to perform basic operations such as:
  - serve a [graphiQL](https://github.com/graphql/graphiql) page;
  - implement a subscription resolver;
  - implement custom graphQL scalars;
  - manage graphQL subscriptions.
