### PR TITLE
Add CaffQL to C/C++ section

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [libgraphqlparser](https://github.com/graphql/libgraphqlparser) - A GraphQL query parser in C++ with C and C++ APIs.
 * [cppgraphqlgen](https://github.com/Microsoft/cppgraphqlgen) - C++ GraphQL schema service generator.
+* [CaffQL](https://github.com/caffeinetv/CaffQL) - Generates C++ client types and request/response serialization from a GraphQL introspection query.
 
 <a name="lib-go" />
 


### PR DESCRIPTION
https://github.com/caffeinetv/CaffQL

This is a code generator that generates C++ types and request/response serialization logic. The basic usage is that you make an introspection query to a graphql endpoint, then use the result as an input to the `caffql` command line program. The program will output a header file that contains types, as well as functions for serializing queries to json and deserializing the responses from json.
