### PR TITLE
Add ArangoDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ for the Angel framework.
 * [Dgraph](https://dgraph.io/) - Scalable, distributed, low latency, high throughput Graph database with GraphQL as the query language
 * [EdgeDB](https://edgedb.com/) - The next generation object-relational database with native GraphQL support.
 * [FaunaDB](https://fauna.com) - Relational NoSQL database with [GraphQL schema import.](https://fauna.com/blog/getting-started-with-graphql-part-1-importing-and-querying-your-schema) Supports joins, indexes, and multi-region ACID transactions with serverless per-per-use pricing.
+* [ArangoDB](https://arangodb.com/) - Native multi-model database with [GraphQL integration](https://www.arangodb.com/docs/3.4/foxx-reference-modules-graph-ql.html) via the built-in [Foxx Microservices Framework](https://www.arangodb.com/docs/stable/foxx.html).
 
 <a name="services" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
[https://www.arangodb.com/docs/3.4/foxx-reference-modules-graph-ql.html](https://www.arangodb.com/docs/3.4/foxx-reference-modules-graph-ql.html)

**[Explain what this resource is all about and why it should be included here.]**
ArangoDB is a native multi-model, open-source database with flexible data models for documents, graphs, and key-values. The built-in Foxx Microservices Framework conveniently integrates GraphQL for use with services.
