### PR TITLE
Added Jaal in Go server libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [c-graphqlparser](https://github.com/tecbot/c-graphqlparser) - Go-gettable version of the libgraphqlparser C library for parsing GraphQL.
 * [tallstreet-graphql](https://github.com/tallstreet/graphql) - GraphQL parser and server for Go that leverages libgraphqlparser
 * [go-graphql](https://github.com/playlyfe/go-graphql) - A powerful GraphQL server implementation for Golang
+* [Jaal](https://github.com/appointy/jaal) - Develop spec-compliant GraphQL servers in Go.
 
 <a name="lib-scala" />
 


### PR DESCRIPTION
[Jaal](https://github.com/appointy/jaal) is a GraphQL server library in Go. 

It is used to create spec-compliant GraphQL servers. It provides support for creating custom scalar types, creating union and interface types and schema-stichting (AKA connections). Explore these features [here](https://github.com/appointy/jaal).


