### PR TITLE
Add GraphQL Nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Community](#community)
 - [Libraries](#lib)
 	- [Javascript](#lib-js)
-        - [Typescript](#lib-ts)
+	- [Typescript](#lib-ts)
 	- [Ruby](#lib-rb)
 	- [PHP](#lib-php)
 	- [Python](#lib-py)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Community](#community)
 - [Libraries](#lib)
 	- [Javascript](#lib-js)
+  - [Typescript](#lib-ts)
 	- [Ruby](#lib-rb)
 	- [PHP](#lib-php)
 	- [Python](#lib-py)
@@ -185,6 +186,12 @@ If you want to contribute to this list (please do), send me a pull request.
 * [react-relay-network-layer](https://github.com/relay-tools/react-relay-network-layer) - A network layer for Relay with query batching and middleware support (urlThunk, retryThunk, auth, defer and other).
 * [relay-subscriptions](https://github.com/relay-tools/relay-subscriptions) - Subscription support for Relay.
 * [Portfolio Relay Example](https://github.com/alex-cory/portfolio) - An example website that fetches data from various apis and uses Relay and GraphQL to feed the data to React components!
+
+<a name="lib-ts" />
+
+### TypeScript Libraries
+
+* [GraphQL Nexus](https://github.com/prisma/nexus) - Declarative, code-first and strongly typed GraphQL schema construction for TypeScript & JavaScript.
 
 <a name="lib-rb" />
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Community](#community)
 - [Libraries](#lib)
 	- [Javascript](#lib-js)
-  - [Typescript](#lib-ts)
+        - [Typescript](#lib-ts)
 	- [Ruby](#lib-rb)
 	- [PHP](#lib-php)
 	- [Python](#lib-py)


### PR DESCRIPTION
**[Github repo](https://github.com/prisma/nexus)**
**[GraphQL Nexus](https://nexus.js.org/)**

GraphQL Nexus aims to combine the simplicity and ease of development of SDL development approaches like graphql-tools with the long-term maintainability of programmatic construction, as seen in graphene-python, graphql-ruby, or graphql-js.

Nexus builds upon the primitives of graphql-js, and attempts to take the simplicity of the SDL schema-first approach and pair it with the power of having the full language runtime at your disposal.

GraphQL Nexus was designed with TypeScript/JavaScript intellisense in mind, and combines TypeScript generics, conditional types, and type merging to provide full auto-generated type coverage out of the box.