### PR TITLE
Added graphiql-storm to graphql tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ for the Angel framework.
 * [graphql-typed-client](https://github.com/helios1138/graphql-typed-client) - A tool that generates a strongly typed client library for any GraphQL endpoint.  The client allows writing GraphQL queries as plain JS objects (with type safety and awesome code completion experience)
 * [OASGraph](https://github.com/strongloop/oasgraph) - Take any OpenAPI Specification (OAS) or swagger and create a GraphQL interface - One minute video and resources [here](https://v4.loopback.io/oasgraph.html)
 * [SwitchQL](https://github.com/SwitchQL/SwitchQL) - Automated transcription of database schemas into GraphQL schemas, resolvers, queries, and mutations
+* [graphiql-storm](https://github.com/Gherciu/graphiql-storm) - An in-browser IDE for exploring GraphQL that allows you to export and import workspaces to share with teammates.
 
 <a name="databases" />
 


### PR DESCRIPTION
[graphiql-storm](https://github.com/Gherciu/graphiql-storm)

1.  Allows you to export and import workspaces to share with teammates.
2. Configuration of HTTP headers
3. Tabs
4. Autocompletion & error highlighting
5. Query history
6. Multi endpoints on different tabs

