### PR TITLE
Add Apollo Client Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ for the Angel framework.
 * [graphql-typed-client](https://github.com/helios1138/graphql-typed-client) - A tool that generates a strongly typed client library for any GraphQL endpoint.  The client allows writing GraphQL queries as plain JS objects (with type safety and awesome code completion experience)
 * [OASGraph](https://github.com/strongloop/oasgraph) - Take any OpenAPI Specification (OAS) or swagger and create a GraphQL interface - One minute video and resources [here](https://v4.loopback.io/oasgraph.html)
 * [SwitchQL](https://github.com/SwitchQL/SwitchQL) - Automated transcription of database schemas into GraphQL schemas, resolvers, queries, and mutations
+* [Apollo Client Developer Tools](https://github.com/apollographql/apollo-client-devtools) - GraphQL debugging tools for Apollo Client in the Chrome developer console
 
 <a name="databases" />
 


### PR DESCRIPTION
**[URL to the resource here.]**

- [Github repo](https://github.com/apollographql/apollo-client-devtools)
- [Chrome Web Store](https://chrome.google.com/webstore/detail/apollo-client-developer-t/jdkknkkbebbapilgoeccciglkfbmbnfm)

**[Explain what this resource is all about and why it should be included here.]**

Apollo Client Developer Tools is a Chrome DevTools extension for the open-source JavaScript GraphQL client, Apollo Client. The extension has 3 main features:

1. A built-in GraphiQL console that allows you to make queries against your GraphQL server using your app's network interface directly (no configuration necessary).

2. A query watcher that shows you which queries are being watched by the current page, when those queries are loading, and what variables those queries are using.

3. A mutation inspector that displays the mutations made to you apollo-client app data.

4. A cache inspector that displays your client-side Redux store in an Apollo-Client-friendly way. You can explore the state of the store through a tree-like interface, and search through the store for specific field keys and values.