### PR TITLE
Add ApolloDeveloperKit for iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### iOS Libraries
 
 * [apollo-ios](https://github.com/apollographql/apollo-ios) - ðŸ“± A strongly-typed, caching GraphQL client for iOS, written in Swift
+* [ApolloDeveloperKit](https://github.com/manicmaniac/ApolloDeveloperKit) - Apollo Client Devtools bridge for [Apollo iOS].
 
 <a name="lib-clojurescript" />
 


### PR DESCRIPTION
**[URL to the resource here.]**

- [Github repo](https://github.com/manicmaniac/ApolloDeveloperKit)

**[Explain what this resource is all about and why it should be included here.]**

ApolloDeveloperKit is an iOS library which works as a bridge between Apollo iOS client and Apollo Client Developer Tools, which was introduced in https://github.com/chentsulin/awesome-graphql/pull/507.
This library adds an ability to watch the sent queries or mutations simultaneously, and also has the feature to request arbitrary operations from embedded GraphiQL console.

As far as I know, there is no library providing that kind of features so I want to introduce this library.