### PR TITLE
Add Zurich Meetup and FakeQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Tel Aviv](https://www.meetup.com/GraphQL-TLV/)
 * [Toronto](https://www.meetup.com/GraphQL-Toronto/)
 * [Wrocław](https://www.meetup.com/GraphQL-Wroclaw/)
+* [Zurich](https://www.meetup.com/GraphQL-Zurich/)
 
 <a name="lib" />
 
@@ -464,6 +465,7 @@ for the Angel framework.
 * [FastQL](https://fastql.io/) - CDN specifically for GraphQL applications
 * [GraphCMS](https://graphcms.com/) - GraphQL based Headless Content Management System.
 * [Graphcool](https://www.graph.cool/) - Your own GraphQL backend in under 5 minutes. Works with every GraphQL client such as Relay and Apollo.
+* [FakeQL](https://fakeql.com/) - GraphQL API mocking as a service ... because GraphQL API mocking should be easy!
 
 <a name="example" />
 


### PR DESCRIPTION
https://www.fakeql.com/

FakeQL is a mocked GraphQL API as a service. It extends minimal sample data and deploys a real server in less than a second. For a full set of features: https://www.fakeql.com/features 
