### PR TITLE
Added elide.io to list of Java Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [vertx-dataloader](https://github.com/engagingspaces/vertx-dataloader) - Port of Facebook DataLoader for efficient, asynchronous batching and caching in clustered GraphQL environments
 * [graphql-spqr](https://github.com/leangen/GraphQL-SPQR) - Java 8+ API for rapid development of GraphQL services.
 * [Light Java GraphQL](https://github.com/networknt/light-graphql-4j): A lightweight, fast microservices framework with all cross-cutting concerns addressed and ready to plug in GraphQL schema.
+* [Elide](https://elide.io): A Java library that can expose a JPA annotated data model as a GraphQL service over any relational database. 
 
 <a name="lib-c" />
 


### PR DESCRIPTION
https://elide.io

Similar to hasura but using Java, supports any RDBMS, and can insulate the service contract from the physical database model.  The library allows a developer to setup a fully featured GraphQL API including filters, pagination, sorting, search, etc.  from a JPA annotated model.