### PR TITLE
Add Caliban to Scala libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [sangria](https://github.com/sangria-graphql/sangria) - Scala GraphQL server implementation.
 * [sangria-relay](https://github.com/sangria-graphql/sangria-relay) - Sangria Relay Support.
 * [graphql-scala](https://github.com/hrosenhorn/graphql-scala) - An attempt to get GraphQL going with Scala.
+* [caliban](https://github.com/ghostdogpr/caliban) - Functional GraphQL backend in Scala.
 
 <a name="lib-dotnet" />
 


### PR DESCRIPTION
https://github.com/ghostdogpr/caliban

Caliban is a new and modern library to build graphql backends in Scala. It embraces functional programming and allows creating schemas without boilerplate.