### PR TITLE
Add graphql-modules, separate GraphQL server into smaller, reusable parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [node-graphjoiner](https://github.com/mwilliamson/node-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.
 * [Join Monster](https://github.com/acarl005/join-monster) - A GraphQL-to-SQL query execution layer for batch data fetching.
 * [graphql-factory](https://github.com/graphql-factory) - Create GraphQL types from JSON definitions
+* [graphql-modules](https://github.com/Urigo/graphql-modules) - Separate GraphQL server into smaller, reusable parts by modules or features.
 * [type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability.
 * [GraphiteJS](https://github.com/graphitejs/server) - Framework NodeJS for GraphQl.
 * [GraphQL Joker](https://github.com/zhangkaiyulw/graphql-joker) - The ultimate GraphQL scaffolding tool.


### PR DESCRIPTION
**graphql-modules:**

[https://github.com/Urigo/graphql-modules](https://github.com/Urigo/graphql-modules)
[https://graphql-modules.com/](https://graphql-modules.com/)

Along with a applications grow, their code and schematic relationships becomes bigger and more complex, which can make schema maintenance a hard and agonizing thing to work with. GraphQL Modules is to separate your GraphQL server into smaller, reusable, feature based parts.