### PR TITLE
Add Firecamp in tool and blog on playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,6 +431,7 @@ for the Angel framework.
 
 ## Tools
 
+* [Firecamp - GraphQL Playground](https://firecamp.app/graphql) - The fastest collaborative GraphQL playground
 * [graphiql](https://github.com/graphql/graphiql) - An in-browser IDE for exploring GraphQL.
 * [GraphiQL.app](https://github.com/skevy/graphiql-app) - A light, Electron-based wrapper around GraphiQL.
 * [GraphQLviz](https://github.com/Macroz/GraphQLviz) - GraphQLviz marries GraphQL (schemas) with Graphviz.
@@ -660,6 +661,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [Official GraphQL blog](https://graphql.org/blog/)
 * [Building Apollo](https://blog.apollographql.com/)
 * [The Guild blog](https://medium.com/the-guild)
+* [Here is the Fastest GraphQL playground](https://hackernoon.com/here-is-the-fastest-graphql-playground-qt2534a8)
 
 <a name="post" />
 


### PR DESCRIPTION
**[https://firecamp.app/graphql]**

**[Firecamp is a full feature playground that helps developers to debug and collaborate to manage the GraphQL APIs. ]**

Blog - **[https://hackernoon.com/here-is-the-fastest-graphql-playground-qt2534a8]**
**[Blog is a descriptive blog on the feature of like how to test file upload in GraphQL, use an interactive variable, Magical GraphQL playground and many more ]**
