### PR TITLE
Added Discord server to the Community section

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ## Community
 
 * [Slack](https://graphql.slack.com/messages/general/) - Share and help people on the chat. Get your invite [here](https://graphql-slack.herokuapp.com/)
+* [Discord](http://join.reactiflux.com/) - Join #graphql on the ReactiFlux Discord server
 * [Facebook](https://www.facebook.com/groups/795330550572866/) - Group for discussions, articles and knowledge sharing
 * [Twitter](https://twitter.com/search?q=%23GraphQL) - Use the hashtag #graphql
 * [StackOverflow](https://stackoverflow.com/questions/tagged/graphql) - Questions and answers. Use the tag [graphql](https://stackoverflow.com/questions/tagged/graphql)


### PR DESCRIPTION
The Discord server in question is the one referenced on the [official GraphQL page](https://graphql.org/community/#slack-discord).

#### References
* [Community Resources | GraphQL](https://graphql.org/community/#slack-discord)

#### Why
Discord is an increasingly popular way of interacting with other developers (just look at the incredibly active and well organized [Rust Discord](https://discord.gg/rust-lang) for example!) working on similar tech. Since Slack is already in this list, I think having the Discord server (that's mentioned in the official GraphQL Community page) should be as well. 
