### PR TITLE
Add storefront-api

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,7 @@ for the Angel framework.
 
 ### JavaScript Examples
 
+* [storefront-api](https://github.com/DivanteLtd/storefront-api) - GraphQL eCommerce API you can connect to any eCommerce backend on the one side and Headless/PWA frontends on the other side,
 * [react-starter-kit](https://github.com/kriasoft/react-starter-kit) - Isomorphic web app boilerplate (Node.js/Express, GraphQL, React)
 * [graphql-starter-kit](https://github.com/kriasoft/nodejs-api-starter) - Project template for building a GraphQL server with Node.js v7+ and JavaScript
 * [swapi-graphql](https://github.com/graphql/swapi-graphql) - A GraphQL schema and server wrapping swapi.co.


### PR DESCRIPTION
**[URL to the resource here.]**

https://github.com/DivanteLtd/storefront-api

**[Explain what this resource is all about and why it should be included here.]**

Storefront GraphQL API. Easy to use. Extendable. Pretty fast. ElasticSearch included. BFF (Backend for frontend) driven. Works with: Magento1, Magento2, Spree, OpenCart, and Pimcore - out of the box. Easy to integrate with custom backends.

You can use the Storefront GraphQL API to integrate all your backend systems with your eCommerce frontend under a single GraphQL/REST API. By default, all catalog information is stored in ElasticSearch, and all the write operations are forwarded to the platform driver (Magento1, Magento2, Spree, and others available).