### PR TITLE
Add Next.js TypeScript and GraphQL example

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [Intuitive GraphQL Resolver Example](https://github.com/xpepermint/graphql-example) - GraphQL application example using [contextable.js](https://github.com/rawmodel/framework).
 * [GraphQL Tutorial](https://github.com/rse/graphql-tutorial) - A didactic 12-step introduction to GraphQL, starting from a simple Hello World to a network-based GraphQL server with a built-in GraphQL UI
 * [Serverless Apollo Graphql](https://github.com/RishikeshDarandale/serverless-graphql-boilerplate) - Boilerplate to start you Apollo graphql server in AWS using serverless framework
+* [Next.js TypeScript and GraphQL Example](https://github.com/zeit/next.js/tree/canary/examples/with-typescript-graphql) - A type-protected GraphQL example on Next.js running [graphql-codegen](https://graphql-code-generator.com/) under the hood
 
 <a name="example-ts" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/zeit/next.js/tree/canary/examples/with-typescript-graphql#readme

**[Explain what this resource is all about and why it should be included here.]**
It's an example included in Next.js project to start type-protected GraphQL development just by typing:

```bash
yarn create next-app --example with-typescript-graphql with-typescript-graphql-app
```

# Why

GraphQL + graphql-codegen enables truly type-protected development on runtime and on type checking. This example achieves the simplest way to start TypeScript + GraphQL + Apollo Client + graphql-codegen development with [graphql-let](https://github.com/piglovesyou/graphql-let), which is a webpack loader and allows users to import codegen results directly from GraphQL documents.

Tech stack:
* [Next.js](https://github.com/zeit/next.js)
* [Apollo Server](https://github.com/apollographql/apollo-server)
* [Apollo Client](https://github.com/apollographql/apollo-client)
* [graphql-codegen](https://github.com/dotansimha/graphql-code-generator)
* [graphql-let](https://github.com/piglovesyou/graphql-let)