### PR TITLE
Add graphql-let, a webpack loader 

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [GraphiteJS](https://github.com/graphitejs/server) - Framework NodeJS for GraphQl.
 * [GraphQL Joker](https://github.com/zhangkaiyulw/graphql-joker) - The ultimate GraphQL scaffolding tool.
 * [reactive-graphql](https://github.com/mesosphere/reactive-graphql) - Implementation of GraphQL based on RxJS and that supports live queries.
+* [graphql-let](https://github.com/piglovesyou/graphql-let) - A webpack loader to import type-protected codegen results directly from GraphQL documents
 
 #### Relay Related
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/piglovesyou/graphql-let#readme

**[Explain what this resource is all about and why it should be included here.]**
It's a webpack loader to import type-protected codegen results directly from GraphQL documents. I explained [why it exists in here](https://github.com/piglovesyou/graphql-let#readme).