### PR TITLE
Add Next.js + TypeScript template

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 ### TypeScript Examples
 
 * [Basic Apollo Server](https://github.com/DxCx/webpack-graphql-server) - Basic Starter for Apollo Server, Using typescript and Webpack.
+* [Next.js Apollo TypeScript Starter](https://github.com/borisowsky/nextjs-apollo-ts-starter) - Next.js starter project focused on developer experience.
 
 <a name="example-rb" />
 


### PR DESCRIPTION
As I see, there is lack of TypeScript examples, so I can suggest to add my template project, which includes built-in GraphQL support (SSR included) via latest version of Apollo Client. 