### PR TITLE
Add django-graphql-auth to Python Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [tartiflette](https://github.com/dailymotion/tartiflette) - GraphQL Implementation, SDL First, for python 3.6+ / asyncio.
 * [tartiflette-aiohttp](https://github.com/dailymotion/tartiflette-aiohttp) - Wrapper of Tartiflette to expose GraphQL API over HTTP based on aiohttp / 3.6+ / asyncio, [official tutorial available on tartiflette.io](https://tartiflette.io/docs/tutorial/getting-started).
 * [Ariadne](https://github.com/mirumee/ariadne) - library for implementing GraphQL servers using schema-first approach. Asynchronous query execution, batteries included for ASGI, WSGI and popular webframeworks, [fully documented](https://ariadnegraphql.org).
+* [django-graphql-auth](https://github.com/PedroBern/django-graphql-auth) - Django registration and authentication with GraphQL.
 
 <a name="lib-java" />
 


### PR DESCRIPTION
source code: [django-graphql-auth](https://github.com/PedroBern/django-graphql-auth)

This package implements django authentication system with GraphQL. It covers:

- registration
- password reset
- email activation
- password change
- delete account
- account update
- secondary email activation
 - login

It is well [documented](https://django-graphql-auth.readthedocs.io/en/latest/).
