### PR TITLE
Added plug and play graphql library on the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [tartiflette](https://github.com/dailymotion/tartiflette) - GraphQL Implementation, SDL First, for python 3.6+ / asyncio.
 * [tartiflette-aiohttp](https://github.com/dailymotion/tartiflette-aiohttp) - Wrapper of Tartiflette to expose GraphQL API over HTTP based on aiohttp / 3.6+ / asyncio, [official tutorial available on tartiflette.io](https://tartiflette.io/docs/tutorial/getting-started).
 * [Ariadne](https://github.com/mirumee/ariadne) - library for implementing GraphQL servers using schema-first approach. Asynchronous query execution, batteries included for ASGI, WSGI and popular webframeworks, [fully documented](https://ariadnegraphql.org).
+* [pnp-graphql](https://github.com/iashraful/pnp-graphql) - A Django integration for GraphQL with Graphene. It's fully plug and play type. No extra code needed to expose basic api with filtering, pagination and mutations.
 
 <a name="lib-java" />
 


### PR DESCRIPTION
[Library Link](https://github.com/iashraful/pnp-graphql)

A library for making GraphQL API with Python/Django. This is like a flash drive, just how you plug into computer and transfer files.
