### PR TITLE
Add Caliban to Scala Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [sangria](https://github.com/sangria-graphql/sangria) - Scala GraphQL server implementation.
 * [sangria-relay](https://github.com/sangria-graphql/sangria-relay) - Sangria Relay Support.
 * [graphql-scala](https://github.com/hrosenhorn/graphql-scala) - An attempt to get GraphQL going with Scala.
+* [https://github.com/ghostdogpr/caliban](https://github.com/hrosenhorn/graphql-scala) - Caliban is a purely functional library for creating GraphQL backends in Scala.
 
 <a name="lib-dotnet" />
 


### PR DESCRIPTION
https://github.com/ghostdogpr/caliban

Caliban is a quite new but stable GraphQL Scala project that propose a purely functional approach with the help of some of the best libraries par of the Scala ecosystem like:
* Magnolia to automatically derives schemas
* Fastparse to parse queries 
* ZIO to handle various effects.
