### PR TITLE
doc: Add pino and lightstep middlewares to list of middlewares

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ If you want to contribute to this list (please do), send me a pull request.
 * [react-reach](https://github.com/kennetpostigo/react-reach) - A library to communicate with Graphql through Redux.
 * [Grafoo](https://github.com/grafoojs/grafoo) - A tiny yet fully fledged cache based GraphQL client
 * [mst-gql](https://github.com/mobxjs/mst-gql) - Bindings for mobx-state-tree and GraphQL
+* [graphql-pino-middleware](https://github.com/addityasingh/graphql-pino-middleware) - GraphQL middleware to augment resolvers with pino logger
+* [graphql-lightstep-middleware](https://github.com/addityasingh/graphql-lightstep-middleware) - GraphQL middleware to instrument resolvers with `lightstep` traces
 
 #### HTTP Server Bindings
 * [express-graphql](https://github.com/graphql/express-graphql) - GraphQL Express Middleware.


### PR DESCRIPTION
Add graphql-pino-middleware, graphql-lightstep-middleware to list of middlewares

**[URL to the resource here.]**
https://github.com/addityasingh/graphql-pino-middleware
https://github.com/addityasingh/graphql-lightstep-middleware

**[Explain what this resource is all about and why it should be included here.]**
Graphql middlewares for lightstep opentracing and pino logging