### PR TITLE
Added blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [REST vs GraphQL](https://www.moesif.com/blog/technical/graphql/REST-vs-GraphQL-APIs-the-good-the-bad-the-ugly/)
 * [Authentication and Authorization for GraphQL APIs](https://www.moesif.com/blog/technical/api-design/Steps-to-Building-Authentication-and-Authorization-For-GraphQL-APIs/)
 * [Build a GraphQL API with Siler on top of Swoole](https://www.swoole.co.uk/article/Build-a-GraphQL-API-on-top-of-Swoole)
+* [Fluent GraphQL clients: how to write queries like a boss](https://hasura.io/blog/fluent-graphql-clients-how-to-write-queries-like-a-boss/)
 
 <a name="workshopper" />
 


### PR DESCRIPTION
Added "Fluent GraphQL clients: how to write queries like a boss"

https://hasura.io/blog/fluent-graphql-clients-how-to-write-queries-like-a-boss/

What if we could write #GraphQL queries as objects instead of strings? 🤔 It turns out we can, thanks to fluent GraphQL clients, with strong typing and autocompletion to boot! (#TypeScript fans rejoice!) Check out this walk-through with examples, and a companion repo.