### PR TITLE
Add the "Everything GraphQL" Discord server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [/r/GraphQL](https://old.reddit.com/r/graphql/) - A Subreddit for interesting and informative GraphQL content and discussions.
 * [GraphQL Jobs](https://graphql.jobs) - A list of GraphQL-based jobs in startups all over the world.
 * [Bookmarks.dev](https://www.bookmarks.dev/search?q=graphql) - Dev bookmarks. Use the tag [graphql](https://www.bookmarks.dev/tagged/graphql)
+* [Everything GraphQL - Curated by The Guild](https://discord.gg/xud7bH9) - A Discord server dedicated to GraphQL
 
 <a name="meetups" />
 


### PR DESCRIPTION
**[https://discord.gg/xud7bH9]**

A Discord server dedicated to GraphQL with different channels for different subjects related to GraphQL.
Actively curated and managed.

