### PR TITLE
Add typescript-graphql-request

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [aws-amplify](https://github.com/aws-amplify/amplify-js) - A client library developed by Amazon for caching, analytics and more that includes a way to fetch GraphQL queries.
 * [graphql-hooks](https://github.com/nearform/graphql-hooks) - Minimal hooks-first GraphQL client with caching and server-side rendering support.
 * [graphql-request](https://github.com/prisma/graphql-request) - A minimal GraphQL client for Node and browsers.
+* [typescript-graphql-request](https://graphql-code-generator.com/docs/plugins/typescript-graphql-request) - Use GraphQL Request as a fully typed SDK.
 * [FetchQL](https://github.com/gucheen/FetchQL) - A simple GraphQL query client using Fetch.
 * [urql](https://github.com/FormidableLabs/urql) - A simple caching GraphQL client for React.
 * [micro-graphql-react](https://github.com/arackaf/micro-graphql-react) - A lightweight utility for adding GraphQL to React. components. Includes simple caching and uses GET requests that could additionally be cached through a service-worker.


### PR DESCRIPTION
[typescript-graphql-request](https://graphql-code-generator.com/docs/plugins/typescript-graphql-request)

If someone wants to use GraphQL Request, it is even better to use it as a fully typed SDK.
Even if you won't use Typescript, your code editor would pick up the types!
