### PR TITLE
Add Graphaello

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,6 +400,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 * [apollo-ios](https://github.com/apollographql/apollo-ios) - 📱 A strongly-typed, caching GraphQL client for iOS, written in Swift
 * [ApolloDeveloperKit](https://github.com/manicmaniac/ApolloDeveloperKit) - Apollo Client Devtools bridge for [Apollo iOS].
+* [Graphaello](https://github.com/nerdsupremacist/Graphaello) - Type Safe GraphQL directly from SwiftUI
 
 <a name="lib-clojurescript" />
 


### PR DESCRIPTION
https://github.com/nerdsupremacist/Graphaello

While I was interning at Facebook last year, I learned how useful Relay could be when building React Apps that use GraphQL.
When SwiftUI came out, I just had to make something similar for Swift. And took some more liberties to make it Swiftier.
