### PR TITLE
Add dataloader-codegen

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ for the Angel framework.
 * [VulcanJS](http://vulcanjs.org) - The full-stack React+GraphQL framework
 * [Apollo Client Developer Tools](https://github.com/apollographql/apollo-client-devtools) - GraphQL debugging tools for Apollo Client in the Chrome developer console
 * [GraphQL Birdseye](https://birdseye.novvum.io) – View any GraphQL schema as a dynamic and interactive graph.
+* [dataloader-codegen](https://github.com/Yelp/dataloader-codegen) - An opinionated JavaScript library for automatically generating predictable, type safe DataLoaders over a set of resources (e.g. HTTP endpoints).
 
 <a name="databases" />
 


### PR DESCRIPTION
We just open sourced this tool!

https://github.com/Yelp/dataloader-codegen

dataloader-codegen is an opinionated JavaScript library for automatically generating DataLoaders over a set of resources (e.g. HTTP endpoints). This is useful for teams that want to maintain type safety and predictability in their DataLoader layer, which is invaluable for scalability.