### PR TITLE
Add GiraphQL Schema builder for typescript

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### TypeScript Libraries
 
 * [GraphQL Nexus](https://github.com/prisma/nexus) - Declarative, code-first and strongly typed GraphQL schema construction for TypeScript & JavaScript.
+* [GiraphQL](https://github.com/hayes/giraphql) -  A plugin based schema builder for creating code-first GraphQL schemas in typescript.
 
 <a name="lib-rb" />
 


### PR DESCRIPTION
https://giraphql.com/ or https://github.com/hayes/giraphql

GiraphQL is a plugin based schema builder for creating code-first GraphQL schemas in typescript.  It enables writing type-safe GraphQL schemas without a compile set, and has a number of plugins for things like auth and relay support.
