### PR TITLE
Added Nhost as a service

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,7 +514,8 @@ for the Angel framework.
 * [GraphCMS](https://graphcms.com/) - GraphQL based Headless Content Management System.
 * [Graphcool](https://www.graph.cool/) - Your own GraphQL backend in under 5 minutes. Works with every GraphQL client such as Relay and Apollo.
 * [FakeQL](https://fakeql.com/) - GraphQL API mocking as a service ... because GraphQL API mocking should be easy!
-* [Moesif API Analytics](https://www.moesif.com/features/graphql-analytics) - A GraphQL analaytics and monitoring service to find functional and performance issues.  
+* [Moesif API Analytics](https://www.moesif.com/features/graphql-analytics) - A GraphQL analaytics and monitoring service to find functional and performance issues.
+* [Nhost](https://www.nhost.io) - PostgreSQL, GraphQL (Hasura), Auth, Storage. Focus on your app, not your backend.
 
 <a name="example" />
 


### PR DESCRIPTION
Added Nhost as service

https://nhost.io

Backend as a Service using Hasura providing a GraphQL (and auth + storage) for developers who wants to build apps!

(https://hasura.io/docs/1.0/graphql/manual/guides/deployment/nhost-one-click.html)

