### PR TITLE
Add GraphQL '98 to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,7 @@ for the Angel framework.
 * [VulcanJS](http://vulcanjs.org) - The full-stack React+GraphQL framework
 * [Apollo Client Developer Tools](https://github.com/apollographql/apollo-client-devtools) - GraphQL debugging tools for Apollo Client in the Chrome developer console
 * [GraphQL Birdseye](https://birdseye.novvum.io) – View any GraphQL schema as a dynamic and interactive graph.
+* [GraphQL '98](https://github.com/marcello3d/graphql-98) - A visual GraphQL data browser, like a SQL GUI for GraphQL
 
 <a name="security-tools" />
 


### PR DESCRIPTION
Link to repo: https://github.com/marcello3d/graphql-98
Link to live demo (this url might change in future): https://graphql-98.vercel.app

This is, as far as I know, the first visual point-and-click data browser for GraphQL.