### PR TITLE
Add Hypi to services list

### DIFF
--- a/README.md
+++ b/README.md
@@ -527,6 +527,7 @@ for the Angel framework.
 * [Graphcool](https://www.graph.cool/) - Your own GraphQL backend in under 5 minutes. Works with every GraphQL client such as Relay and Apollo.
 * [FakeQL](https://fakeql.com/) - GraphQL API mocking as a service ... because GraphQL API mocking should be easy!
 * [Moesif API Analytics](https://www.moesif.com/features/graphql-analytics) - A GraphQL analaytics and monitoring service to find functional and performance issues.  
+* [Hypi](https://hypi.io/) - Low-code, scalable, serverless backend as a service. Your GraphQL & REST over GraphQL backend in minutes.
 
 <a name="example" />
 


### PR DESCRIPTION
Add hypi.io low-code cloud and on-prem service to list of GraphQL services

**https://hypi.io**

Hypi is a low-code backend as a service which makes it easy to build scalable applications with easy and max flexibility. The platform comes loaded with functionality in an effort to offer comprehensive feature set to build almost any kind of application. CRUD, Authorisation, Serverless, Scripting, Workflows, Realtime...to name a few
