### PR TITLE
add GraphQL weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [/r/GraphQL](https://old.reddit.com/r/graphql/) - A Subreddit for interesting and informative GraphQL content and discussions.
 * [GraphQL Jobs](https://graphql.jobs) - A list of GraphQL-based jobs in startups all over the world.
 * [Bookmarks.dev](https://www.bookmarks.dev/search?q=graphql) - Dev bookmarks. Use the tag [graphql](https://www.bookmarks.dev/tagged/graphql)
+* [GraphQL Weekly](https://www.graphqlweekly.com/) - A weekly newsletter highlighting resources and news from the GraphQL community
 
 <a name="meetups" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://www.graphqlweekly.com/

**[Explain what this resource is all about and why it should be included here.]**
GraphQL weekly is a weekly newsletter curated by Prisma. It goes out every Friday and includes links to valuable resources for the GraphQL Community.

Once a month, the GraphQL Weekly Foundation Edition goes out. This is a special edition which includes links to updates from the GraphQL Foundation.

It should be included because it's a great way for the GraphQL community to keep up-to-date with what's happening in the world of GraphQL.
