### PR TITLE
Added new JS library in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [reactive-graphql](https://github.com/mesosphere/reactive-graphql) - Implementation of GraphQL based on RxJS and that supports live queries.
 * [Preact-urql](https://github.com/FormidableLabs/urql/tree/master/packages/preact-urql) - Preact integration for urql.
 * [graphql-let](https://github.com/piglovesyou/graphql-let) - A webpack loader to import type-protected codegen results directly from GraphQL documents
+* [graphql-ably-pubsub](https://www.npmjs.com/package/graphql-ably-pubsub) - Ably PubSub implementation for GraphQL to publish mutation updates and subscribe to the result through a subscription query.
 
 #### Relay Related
 


### PR DESCRIPTION
Added new js library to the list:

https://www.npmjs.com/package/graphql-ably-pubsub 

Ably is a pub/sub messaging platform with a suite of integrated services to deliver complete realtime functionality directly to end-users. In the context of GraphQL, we can use it to publish when a mutation is fired and subscribe to the result through a subscription query.

This package implements the PubSubEngine Interface from the graphql-subscriptions package and also the new AsyncIterator interface. It allows you to connect your subscription manger to an Ably PubSub mechanism to support multiple subscription manager instances.
