### PR TITLE
📝 Added GraphQL Starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -580,6 +580,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 
 * [Basic Apollo Server](https://github.com/DxCx/webpack-graphql-server) - Basic Starter for Apollo Server, Using typescript and Webpack.
 * [Next.js Apollo TypeScript Starter](https://github.com/borisowsky/nextjs-apollo-ts-starter) - Next.js starter project focused on developer experience.
+* [GraphQL Starter](https://github.com/cerino-ligutom/GraphQL-Starter) - A boilerplate for TypeScript + Node Express + Apollo GraphQL APIs.
 
 <a name="example-rb" />
 


### PR DESCRIPTION
Added a link to GraphQL Starter under Typescript Examples

https://github.com/cerino-ligutom/GraphQL-Starter

A very well designed and documented boilerplate. 