### PR TITLE
Add gql

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [hapi-plugin-graphiql](https://github.com/rse/hapi-plugin-graphiql) - HAPI plugin for GraphiQL integration.
 * [graphql-api-koa](https://github.com/jaydenseric/graphql-api-koa) - GraphQL Koa middleware that implements GraphQL.js from scratch and supports native ESM.
 * [koa-graphql](https://github.com/chentsulin/koa-graphql) - GraphQL Koa Middleware.
+* [gql](https://github.com/deno-libs/gql) - Universal GraphQL HTTP middleware for Deno.
 
 #### Database & ORM
 * [graphql-bookshelf](https://github.com/brysgo/graphql-bookshelf) - Some help defining GraphQL schema around BookshelfJS models.


### PR DESCRIPTION
https://github.com/deno-libs/gql

gql is an universal GraphQL HTTP middleware for Deno. It works with builtin `std/http`, Opine and tinyhttp out of the box.

Most important features:
- request context
- GraphQL Playground integration
