### PR TITLE
added gqldoc in the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ for the Angel framework.
 * [VulcanJS](http://vulcanjs.org) - The full-stack React+GraphQL framework
 * [Apollo Client Developer Tools](https://github.com/apollographql/apollo-client-devtools) - GraphQL debugging tools for Apollo Client in the Chrome developer console
 * [GraphQL Birdseye](https://birdseye.novvum.io) – View any GraphQL schema as a dynamic and interactive graph.
+* [gqldoc](https://github.com/Code-Hex/gqldoc) - The easiest way to make API documents for GraphQL. 
 
 <a name="security-tools" />
 


### PR DESCRIPTION
- https://github.com/Code-Hex/gqldoc
- https://github.com/Code-Hex/gqldoc-actions

gqldoc can generate API documentation from GraphQL schema as markdown. It also provides GitHub Actions, which make it easy to continuously update documentation using CI.

I created the PR to encourage more people to use it.


