### PR TITLE
Add hypothesis-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [Ariadne](https://github.com/mirumee/ariadne) - library for implementing GraphQL servers using schema-first approach. Asynchronous query execution, batteries included for ASGI, WSGI and popular webframeworks, [fully documented](https://ariadnegraphql.org).
 * [pnp-graphql](https://github.com/iashraful/pnp-graphql) - A Django integration for GraphQL with Graphene. It's fully plug and play type. No extra code needed to expose basic api with filtering, pagination and mutations.
 * [django-graphql-auth](https://github.com/PedroBern/django-graphql-auth) - Django registration and authentication with GraphQL.
+* [hypothesis-graphql](https://github.com/Stranger6667/hypothesis-graphql) - Property-based testing tool that generates arbitrary GraphQL queries for the given schema.
 
 <a name="lib-java" />
 


### PR DESCRIPTION
**https://github.com/Stranger6667/hypothesis-graphql**

This library leverages [Hypothesis](https://github.com/HypothesisWorks/hypothesis) machinery that allows you to generate queries matching the given schema, which is helpful for testing GraphQL apps. Queries could be nested, have different args, etc.

For example, if we take [the schema](https://github.com/dbsystel/1BahnQL/blob/develop/schema.js) from the Deutsche Bahn GraphQL app and run it with hypothesis-graphql, then it will find a server error in a few seconds:

```python
from hypothesis import given, settings
from hypothesis_graphql import strategies as st
import requests

SCHEMA = "..."  # Full schema goes here

@given(query=st.query(schema))
@settings(deadline=None)
def test_api(query):
    response = requests.post(
        "https://bahnql.herokuapp.com/graphql",
        json={"query": query},
    )
    assert response.status_code != 500, response.content
```

It actually uncovers multiple errors (the generation is randomized), here is what it may fail with:

```json
"errors":[{"message":"Cannot read property \'city\' of undefined","locations":[{"line":1,"column":28}],"path":["search","stations"]}],"data":null}
```

I.e., it allows tools like [Schemathesis](https://github.com/schemathesis/schemathesis) to automatically generate tests for GraphQL apps.
