### PR TITLE
Add kriasoft/node-starter-kit to examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -601,6 +601,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [Basic Apollo Server](https://github.com/DxCx/webpack-graphql-server) - Basic Starter for Apollo Server, Using typescript and Webpack.
 * [Next.js Apollo TypeScript Starter](https://github.com/borisowsky/nextjs-apollo-ts-starter) - Next.js starter project focused on developer experience.
 * [GraphQL Starter](https://github.com/cerino-ligutom/GraphQL-Starter) - A boilerplate for TypeScript + Node Express + Apollo GraphQL APIs.
+* [Node.js API Starter Kit](https://github.com/kriasoft/node-starter-kit) - Database-first, code-first GraphQL API starter kit for Node.js.
 
 <a name="example-rb" />
 


### PR DESCRIPTION
https://github.com/kriasoft/node-starter-kit - Database-first, code-first GraphQL API template for Node.js.

#### Features

- Database first design; auto-generated strongly typed data models (TypeScript)
- Authentication and authorization using OAuth 2.0 providers (Google, Facebook, GitHub, etc.)
- Stateless sessions implemented with JWT tokens and a session cookie (compatible with SSR)
- GraphQL API example, implemented using the code-first development approach
- Database schema migration, seeds, and REPL shell tooling
- Transactional emails using Handlebars templates and instant email previews
- Structured logs and error reporting to Google StackDriver
- Pre-configured unit testing tooling powered by [Jest](https://jestjs.io/) and [Supertest](https://github.com/visionmedia/supertest)
- Application bundling with Rollup as an optimization technique for serverless deployments
- Rebuilds and restarts the app on changes when running locally
- Pre-configured for `local`, `dev`, `test`, and `prod` environments

![](https://files.tarkus.me/graphql-api.png)
