### PR TITLE
Adding two example/sample repositories related to GraphQL Java Kickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,8 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [light-java-graphql examples](https://github.com/networknt/light-example-4j/tree/master/graphql) - Examples of Light Java GraphQL and tutorials.
 * [graphql-spqr-samples](https://github.com/leangen/graphql-spqr-samples) - An example GraphQL server written with Spring MVC and GraphQL-SPQR
 * [manifold-graphql sample](https://github.com/manifold-systems/manifold-sample-graphql-app) - A simple application, both client and server, demonstrating the Manifold GraphQL library.
+* [graphql-java-kickstart_samples](https://github.com/graphql-java-kickstart/samples) - Samples for using the GraphQL Java Kickstart projects
+* [spring-boot-federation-example](https://github.com/setchy/spring-boot-federation-example) - A GraphQL Java Kickstart federation example
 
 <a name="example-android" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
* https://github.com/graphql-java-kickstart/samples
* https://github.com/setchy/spring-boot-federation-example

**[Explain what this resource is all about and why it should be included here.]**
* Sample projects for using GraphQL Java Kickstart in a variety of ways, including an Apollo Federation example