### PR TITLE
Adding Apollo Sandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ for the Angel framework.
 * [Apollo Client Developer Tools](https://github.com/apollographql/apollo-client-devtools) - GraphQL debugging tools for Apollo Client in the Chrome developer console
 * [GraphQL Birdseye](https://birdseye.novvum.io) – View any GraphQL schema as a dynamic and interactive graph.
 * [gqldoc](https://github.com/Code-Hex/gqldoc) - The easiest way to make API documents for GraphQL. 
+* [Apollo Sandbox](https://sandbox.apollo.dev/) - The quickest way to navigate and test your GraphQL endpoints.
 
 <a name="security-tools" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
* https://sandbox.apollo.dev/

**[Explain what this resource is all about and why it should be included here.]**
* The quickest way to navigate and test your GraphQL endpoints
* https://www.apollographql.com/blog/announcement/platform/apollo-sandbox-an-open-graphql-ide-for-local-development/