### PR TITLE
Add graphql-modules, separate GraphQL server into smaller, reusable parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [gql-tools](https://github.com/almilo/gql-tools) - Tool library with CLI for schema generation and manipulation.
 * [graphql-iso-date](https://github.com/excitement-engineer/graphql-iso-date) - A GraphQL date scalar type to be used with GraphQL.js. This scalar represents a date in the ISO 8601 format YYYY-MM-DD.
 * [graphql-compose](https://github.com/graphql-compose/graphql-compose) - Tool which allows you to construct flexible graphql schema from different data sources via plugins.
+* [graphql-modules](https://github.com/Urigo/graphql-modules) - Separate GraphQL server into smaller, reusable parts by modules or features.
 * [node-graphjoiner](https://github.com/mwilliamson/node-graphjoiner) - Create GraphQL APIs using joins, SQL or otherwise.
 * [Join Monster](https://github.com/acarl005/join-monster) - A GraphQL-to-SQL query execution layer for batch data fetching.
 * [type-o-rama](https://github.com/stereobooster/type-o-rama) - JS type systems interportability.


### PR DESCRIPTION
**graphql-modules**:

- [https://github.com/Urigo/graphql-modules](https://github.com/Urigo/graphql-modules)
- [https://graphql-modules.com/](https://graphql-modules.com/)

Along with applications growth, their code and schematic relationships become bigger and more complex, which can make schema maintenance a hard and agonizing thing to work with. GraphQL Modules is to separate your GraphQL server into smaller, reusable, feature-based parts.

The idea behind this is to implement the [Separation of Concerns](https://deviq.com/separation-of-concerns/) design pattern in GraphQL and to allow you to write simple modules that only do what they need to. This way, they're easier to write, maintain and test.

---

@chentsulin This PR was created for replacing the conflicted one #538 .
