### PR TITLE
added mercurius

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ If you want to contribute to this list (please do), send me a pull request.
 * [graphql-api-koa](https://github.com/jaydenseric/graphql-api-koa) - GraphQL Koa middleware that implements GraphQL.js from scratch and supports native ESM.
 * [koa-graphql](https://github.com/chentsulin/koa-graphql) - GraphQL Koa Middleware.
 * [gql](https://github.com/deno-libs/gql) - Universal GraphQL HTTP middleware for Deno.
+* [mercurius](https://github.com/mercurius-js/mercurius) - GraphQL plugin for Fastify
 
 #### Database & ORM
 * [graphql-bookshelf](https://github.com/brysgo/graphql-bookshelf) - Some help defining GraphQL schema around BookshelfJS models.


### PR DESCRIPTION
**[URL to the resource here.]**
[github](https://github.com/mercurius-js/mercurius)
[homepage](https://mercurius.dev/)

**[Explain what this resource is all about and why it should be included here.]**
It is an plugin / adapter / middleware for fastify, should be included in the list as there are other middlewares (for express for example)
