### PR TITLE
Add StackBlitz GraphQL playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,6 +635,7 @@ Boilerplate + examples for React Native (iOS, Android), React (isomorphic, Mater
 * [GraphQL Tutorial](https://github.com/rse/graphql-tutorial) - A didactic 12-step introduction to GraphQL, starting from a simple Hello World to a network-based GraphQL server with a built-in GraphQL UI
 * [Serverless Apollo Graphql](https://github.com/RishikeshDarandale/serverless-graphql-boilerplate) - Boilerplate to start you Apollo graphql server in AWS using serverless framework
 * [Next.js TypeScript and GraphQL Example](https://github.com/zeit/next.js/tree/canary/examples/with-typescript-graphql) - A type-protected GraphQL example on Next.js running [graphql-codegen](https://graphql-code-generator.com/) under the hood
+* [GraphQL StackBlitz Starter](https://stackblitz.com/fork/graphql) – A live, editable demo spinning up in about 2 seconds and running in a browser
 
 <a name="example-ts" />
 


### PR DESCRIPTION
Adds https://stackblitz.com/fork/graphql

A live, editable demo spinning up in about 2 seconds and running in a browser - giving devs a place to play with building schema and run it in `express-graphql` server immediately, with no required setup.
