### PR TITLE
Add Stargate

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ for the Angel framework.
 * [Moesif API Analytics](https://www.moesif.com/features/graphql-analytics) - A GraphQL analaytics and monitoring service to find functional and performance issues.
 * [Booster framework](https://booster.cloud/) - An open-source framework that makes you _completely_ forget about infrastructure and allows you to focus exclusively on your business logic. It autogenerates a GraphQL API for your models, supporting mutations, queries, and subscriptions.
 * [Hypi](https://hypi.io/) - Low-code, scalable, serverless backend as a service. Your GraphQL & REST over GraphQL backend in minutes.
+* [Stargate](https://stargate.io/docs/stargate/1.0/quickstart/quick_start-graphql.html) - Open source data gateway currently supporting Apache Cassandra&reg; and DataStax Enterprise.
 
 <a name="example" />
 


### PR DESCRIPTION
https://stargate.io/docs/stargate/1.0/quickstart/quick_start-graphql.html

Stargate is an open source data gateway that exposes a GraphQL service on top of existing data within Apache Cassandra or DataStax Enterprise.
