### PR TITLE
Add mocked managed federation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Node.js API Starter](https://github.com/kriasoft/nodejs-api-starter) - Yarn v2 based monorepo template (code-first GraphQL API, PostgreSQL, PnP, Zero-install, serverless).
 - [Next.js Apollo TypeScript Starter](https://github.com/borisowsky/nextjs-apollo-ts-starter) - Next.js starter project focused on developer experience.
 - [GraphQL Starter](https://github.com/cerino-ligutom/GraphQL-Starter) - A boilerplate for TypeScript + Node Express + Apollo GraphQL APIs.
+- [Mocked Managed Federation](https://github.com/setchy/apollo-server-3-mocked-federation) - A mocked managed federation supgraph using Apollo Server 3.x
 
 <a name="rb" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/setchy/apollo-server-3-mocked-federation

**[Explain what this resource is all about and why it should be included here.]**
A typescript example of mocking a managed federation supgraph using Apollo Server 3