### PR TITLE
chore(tools): Add CraftQL in Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [GraphQL Birdseye](https://github.com/Novvum/graphql-birdseye) – View any GraphQL schema as a dynamic and interactive graph.
 - [AST Explorer](https://astexplorer.net/) - Select "GraphQL" at the top, explore the GraphQL AST and highlight different parts by clicking in the query.
 - [Firecamp - GraphQL Playground](https://firecamp.io/graphql) - The fastest collaborative GraphQL playground.
+- [CraftQL](https://github.com/yamafaktory/craftql) - A CLI tool to visualize GraphQL schemas and to output a graph data structure as a graphviz .dot format.
 
 <a name="tool-security" />
 


### PR DESCRIPTION
https://github.com/yamafaktory/craftql

CraftQL is a CLI tool to visualize GraphQL schemas and to output a graph data structure as a graphviz .dot format.
