### PR TITLE
Added Blendbase to GraphQL tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [dataloader-codegen](https://github.com/Yelp/dataloader-codegen) - An opinionated JavaScript library for automatically generating predictable, type safe DataLoaders over a set of resources (e.g. HTTP endpoints).
 - [raphql-inspector](https://github.com/kamilkisiela/graphql-inspector): alidate schema, get schema change notifications, validate operations, find breaking changes, look for similar types, schema coverage.
 - [amplication](https://github.com/amplication/amplication): Amplication is an open‑source low code development tool. It builds database applications with REST API and GraphQL for CRUD with relations, sorting, filtering, pagination.
+- [Blendbase](https://github.com/blendbase/blendbase): Single open-source GraphQL API to connect CRMs to your SaaS. Query any customer CRM system (Salesforce, Hubspot and more) with a single API query from your SaaS app.
 
 <a name="databases" />
 


### PR DESCRIPTION
[github.com/blendbase/blendbase](github.com/blendbase/blendbase)

**Blendbase is an open-source unified CRM API that simplifies the way application engineers are building integrations by providing a single GraphQL API to access customer’s CRM systems: Salesforce, Hubspot, etc instead of building integration layer for each third-party service on their own.**
