### PR TITLE
Add Schemathesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [graphql-live-query](https://github.com/n1ru4l/graphql-live-query) - Realtime GraphQL Live Queries with JavaScript.
 - [GraphVinci](https://github.com/Comcast/graphvinci) - An interactive schema visualizer for GraphQL APIs.
 - [supertest-graphql](https://github.com/alexstrat/supertest-graphql) - Extends [supertest](https://github.com/visionmedia/supertest) to easily test a GraphQL endpoint
+- [schemathesis](https://github.com/schemathesis/schemathesis) - Runs arbitrary queries matching a GraphQL schema to find server errors.
 
 <a name="js-example" />
 


### PR DESCRIPTION
**https://github.com/schemathesis/schemathesis**

Schemathesis allows users to test GraphQL endpoints by running arbitrary queries against their backends. Generated queries have arbitrary depth and may contain any subset of GraphQL types defined in the input schema. They aim to expose edge cases in code that are unlikely to be found otherwise.
