### PR TITLE
Add undocumented directive post to posts section

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Level up your serverless game with a GraphQL data-as-a-service layer](https://hasura.io/blog/level-up-your-serverless-game-with-a-graphql-data-as-a-service-layer/)
 - [A deep-dive into Relay, the friendly & opinionated GraphQL client](https://hasura.io/blog/deep-dive-into-relay-graphql-client/)
 - [make your graphql api easier to adopt through components](https://hackernoon.com/make-your-graphql-api-easier-to-adopt-through-components-74b022f195c1)
+- [Undocumented: keeping parts of your GraphQL schema hidden from introspection](https://www.useanvil.com/blog/engineering/undocumented-directive/)
 
 <a name="workshopper" />
 


### PR DESCRIPTION
https://www.useanvil.com/blog/engineering/undocumented-directive/

[Keeping certain parts of your GraphQL schema hidden from Introspection](https://www.useanvil.com/blog/engineering/undocumented-directive/) helps people keep certain parts of their GraphQL schema private. e.g. admin queries, special resolvers and the like.
