### PR TITLE
Add GraphQLite iOS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [apollo-ios](https://github.com/apollographql/apollo-ios) - 📱 A strongly-typed, caching GraphQL client for iOS, written in Swift.
 - [ApolloDeveloperKit](https://github.com/manicmaniac/ApolloDeveloperKit) - Apollo Client Devtools bridge for [Apollo iOS].
 - [Graphaello](https://github.com/nerdsupremacist/Graphaello) - Type Safe GraphQL directly from SwiftUI.
+- [GQLite iOS SDK](https://graphqlite.com/sdk-ios) - GQLite iOS SDK is a toolkit to work with GraphQL servers easily.
 
 <a name="ios-example" />
 


### PR DESCRIPTION
https://graphqlite.com/sdk-ios

GraphQLite iOS SDK is a toolkit to work with GraphQL servers easily.