### PR TITLE
Add GraphMan

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Altair GraphQL Client](https://github.com/altair-graphql/altair) - A beautiful feature-rich GraphQL Client for all platforms.
 - [Insomnia](https://insomnia.rest/) - A full-featured API client with first-party GraphQL query editor.
 - [Postman](https://learning.postman.com/docs/sending-requests/supported-api-frameworks/graphql/) - An HTTP Client that supports editing GraphQL queries.
+- [Escape GraphMan](https://github.com/Escape-Technologies/graphman) - Generate a complete Postman collection from a GraphQL endpoint.
 - [Apollo Sandbox](https://sandbox.apollo.dev/) - The quickest way to navigate and test your GraphQL endpoints.
 - [GraphQL Birdseye](https://github.com/Novvum/graphql-birdseye) – View any GraphQL schema as a dynamic and interactive graph.
 - [AST Explorer](https://astexplorer.net/) - Select "GraphQL" at the top, explore the GraphQL AST and highlight different parts by clicking in the query.


### PR DESCRIPTION
GraphMan is an open-source CLI tool that auto-generates a complete collection of requests for Postman from a GraphQL API endpoint. It makes effortless discovering, documenting and testing your API. GraphMan is developed by [Escape](https://escape.tech)

GrapMan repo: https://github.com/Escape-Technologies/graphman/