### PR TITLE
build-fix-removed-unavailable-links-with-403

### DIFF
--- a/README.md
+++ b/README.md
@@ -811,7 +811,6 @@ If you want to contribute to this list (please do), send me a pull request.
 - [9 GraphQL Security Best Practices](https://blog.escape.tech/9-graphql-security-best-practices/)
 - [Discovering GraphQL Endpoints and SQLi Vulnerabilities](https://medium.com/@localh0t/discovering-graphql-endpoints-and-sqli-vulnerabilities-5d39f26cea2e)
 - [Securing GraphQL API](https://lab.wallarm.com/securing-graphql-api/)
-- [How to secure a GraphQL API (The Complete Vulnerability Checklist)](https://leapgraph.com/graphql-api-security)
 - [Security Points to Consider Before Implementing GraphQL](https://nordicapis.com/security-points-to-consider-before-implementing-graphql/)
 
 <a name="post" />

--- a/README.md
+++ b/README.md
@@ -712,7 +712,6 @@ If you want to contribute to this list (please do), send me a pull request.
 - [FaunaDB](https://fauna.com) - Relational NoSQL database with [GraphQL schema import.](https://fauna.com/blog/getting-started-with-graphql-part-1-importing-and-querying-your-schema) Supports joins, indexes, and multi-region ACID transactions with serverless pay-per-use pricing.
 - [ArangoDB](https://arangodb.com/) - Native multi-model database with [GraphQL integration](https://www.arangodb.com/docs/3.4/foxx-reference-modules-graph-ql.html) via the built-in [Foxx Microservices Framework](https://www.arangodb.com/docs/stable/foxx.html).
 - [Weaviate](https://github.com/semi-technologies/weaviate) - Weaviate is a cloud-native, modular, real-time vector search engine with a [GraphQL interface](https://www.semi.technology/developers/weaviate/current/graphql-references/) built to scale your machine learning models.
-- [Back4App](https://www.back4app.com/graphql-database) - Build a Scalable Database with GraphQL API in minutes.
 - [LunaSec](https://www.lunasec.io/) - Key-Value Database for encrypting/tokenizing sensitive data with [GraphQL support](https://www.lunasec.io/docs/pages/getting-started/dedicated-tokenizer/graphql/) to authorize requests. - [Source Code](https://github.com/lunasec-io/lunasec)
 
 <a name="services" />
@@ -744,7 +743,6 @@ If you want to contribute to this list (please do), send me a pull request.
 ## Books
 
 - [The GraphQL Guide](https://graphql.guide) by John Resig and Loren Sands-Ramshaw
-- [Learning GraphQL](https://www.amazon.com/dp/1492030716) by Eve Porcello and Alex Banks
 - [Craft GraphQL APIs in Elixir with Absinthe](https://pragprog.com/book/wwgraphql/craft-graphql-apis-in-elixir-with-absinthe) by Bruce Williams and Ben Wilson
 - [The Road to GraphQL](https://www.roadtographql.com/)
 - [Fullstack GraphQL](https://www.graphql.college/fullstack-graphql) by Julian Mayorga


### PR DESCRIPTION
While Checking links during build some links are not available at all 

```
Checking URLs: →✓→✓✓→✓→→✓✓→✓✓✓✓✓✓✓✓✓✓→✓✓✓✓✓✓→✓✓✓✓✓✓✓✓✓✓→✓✓✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓→✓✓✓→✓→→✓✓✓✓✓→✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓→→→✓✓✓✓✓→→✓✓✓✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓→✓✓✓✓✓✓✓→✓✓x✓xxxxxx✓✓x✓✓xx✓x✓xxxxx✓xxxx✓xxxxxx✓xxxxxxxxxxxxx✓xxxxxxxxxxxxxxxx✓xxxxxxxxxxxxxx→✓xxxxx✓xxxxxx✓xxxxxxxxxx✓xxx✓xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx→→✓x→✓✓xx→xxxxx✓✓✓xxxxxxx✓x✓xxx✓xxxxx✓✓✓→✓→✓x✓→xx✓✓→✓✓✓→x→✓→✓→→✓✓→→✓✓✓✓✓✓✓✓→✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓x✓✓✓✓✓✓→✓✓✓✓✓✓✓✓✓✓x✓✓✓→✓✓✓✓✓✓→✓✓✓✓→✓✓✓✓✓✓✓→✓→→✓xx✓✓✓✓✓✓✓✓?

Issues :-(
> Links 
  1. [L715] 403 https://www.back4app.com/graphql-database  
  2. [L814]  https://leapgraph.com/graphql-api-security Failed to open TCP connection to leapgraph.com:443 (Connection timed out - connect(2) for "leapgraph.com" port 443) 
```

So removed them

**[URL to the resource here.]**

**[Explain what this resource is all about and why it should be included here.]**
