### PR TITLE
add EntityGraphQL in .Net libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,6 +459,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [graphql-net](https://github.com/ckimes89/graphql-net) - GraphQL to IQueryable for .NET.
 - [Hot Chocolate](https://github.com/ChilliCream/hotchocolate) - GraphQL server for .Net Core and .NET Framework.
 - [Snowflaqe](https://github.com/Zaid-Ajaj/Snowflaqe) - Type-safe GraphQL code generator for F# and [Fable](https://github.com/fable-compiler/Fable)
+- [EntityGraphQL](https://github.com/EntityGraphQL/EntityGraphQL) - library to build a GraphQL API on top of data model with the extensibility to bring multiple data sources together in the single GraphQL schema.
 
 <a name="elixir" />
 


### PR DESCRIPTION
[EntityGraphQL](https://github.com/EntityGraphQL/EntityGraphQL)

Can build GraphQL API on top of data,include multiple data sources together in the single schema. EF is not requirement
,works with any LinqProvider