### PR TITLE
Add morpheus-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Haskell
 
 - [graphql-haskell](https://github.com/jdnavarro/graphql-haskell) - GraphQL AST and parser for Haskell.
+- [morpheus-graphql](https://github.com/morpheusgraphql/morpheus-graphql) - Haskell GraphQL Api, Client and Tools.
 
 <a name="sql" />
 


### PR DESCRIPTION
https://morpheusgraphql.com/

Morpheus GraphQL (Server & Client) helps you to build GraphQL APIs in Haskell with native Haskell types. Morpheus will convert your Haskell types to a GraphQL schema and all your resolvers are just native Haskell functions. Morpheus GraphQL can also convert your GraphQL Schema or Query to Haskell types and validate them in compile time.
