### PR TITLE
Add ILLA Cloud to Tools - Miscellaneous

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,8 +730,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [amplication](https://github.com/amplication/amplication): Amplication is an open‑source low code development tool. It builds database applications with REST API and GraphQL for CRUD with relations, sorting, filtering, pagination.
 - [Blendbase](https://github.com/blendbase/blendbase): Single open-source GraphQL API to connect CRMs to your SaaS. Query any customer CRM system (Salesforce, Hubspot and more) with a single API query from your SaaS app.
 - [microfiber](https://github.com/anvilco/graphql-introspection-tools) - Query and manipulate GraphQL introspection query results in useful ways.
-- [ILLA Cloud](https://www.illacloud.com/) – Open-source low-code tool building platform utilizing GraphQL APIs and featuring a schema explorer
-
+- [ILLA Cloud](https://www.illacloud.com/) – Open-source low-code tool building platform provides an easy way to integrate with GraphQL with minimal configurations
 <a name="databases" />
 
 ## Databases

--- a/README.md
+++ b/README.md
@@ -731,6 +731,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Blendbase](https://github.com/blendbase/blendbase): Single open-source GraphQL API to connect CRMs to your SaaS. Query any customer CRM system (Salesforce, Hubspot and more) with a single API query from your SaaS app.
 - [microfiber](https://github.com/anvilco/graphql-introspection-tools) - Query and manipulate GraphQL introspection query results in useful ways.
 - [ILLA Cloud](https://www.illacloud.com/) – Open-source low-code tool building platform provides an easy way to integrate with GraphQL with minimal configurations
+
 <a name="databases" />
 
 ## Databases

--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [amplication](https://github.com/amplication/amplication): Amplication is an open‑source low code development tool. It builds database applications with REST API and GraphQL for CRUD with relations, sorting, filtering, pagination.
 - [Blendbase](https://github.com/blendbase/blendbase): Single open-source GraphQL API to connect CRMs to your SaaS. Query any customer CRM system (Salesforce, Hubspot and more) with a single API query from your SaaS app.
 - [microfiber](https://github.com/anvilco/graphql-introspection-tools) - Query and manipulate GraphQL introspection query results in useful ways.
+- [ILLA Cloud](https://www.illacloud.com/) – Builder of internal tools utilizing GraphQL APIs and featuring a schema explorer
 
 <a name="databases" />
 

--- a/README.md
+++ b/README.md
@@ -730,7 +730,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [amplication](https://github.com/amplication/amplication): Amplication is an open‑source low code development tool. It builds database applications with REST API and GraphQL for CRUD with relations, sorting, filtering, pagination.
 - [Blendbase](https://github.com/blendbase/blendbase): Single open-source GraphQL API to connect CRMs to your SaaS. Query any customer CRM system (Salesforce, Hubspot and more) with a single API query from your SaaS app.
 - [microfiber](https://github.com/anvilco/graphql-introspection-tools) - Query and manipulate GraphQL introspection query results in useful ways.
-- [ILLA Cloud](https://www.illacloud.com/) – Builder of internal tools utilizing GraphQL APIs and featuring a schema explorer
+- [ILLA Cloud](https://www.illacloud.com/) – Open-source low-code tool building platform utilizing GraphQL APIs and featuring a schema explorer
 
 <a name="databases" />
 


### PR DESCRIPTION
**https://www.illacloud.com/**

**ILLA Cloud is an open-source alternative to Retool, a low-code tool builder. ILLA provides an easy way to integrate with GraphQL and enables users to perform different operations with minimal configurations.**
