### PR TITLE
Deprecate express-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,6 @@ If you want to contribute to this list (please do), send me a pull request.
 #### Servers
 
 - [apollo-server](https://github.com/apollographql/apollo-server) - Spec-compliant and production ready JavaScript GraphQL server that lets you develop in a schema-first way. Built for Express, Connect, Hapi, Koa, and more.
-- [express-graphql](https://github.com/graphql/express-graphql) - GraphQL Express Middleware.
 - [hapi-graphql](https://github.com/SimonDegraeve/hapi-graphql) - Create a GraphQL HTTP server with Hapi.
 - [hapi-plugin-graphiql](https://github.com/rse/hapi-plugin-graphiql) - HAPI plugin for GraphiQL integration.
 - [graphql-api-koa](https://github.com/jaydenseric/graphql-api-koa) - GraphQL Koa middleware that implements GraphQL.js from scratch and supports native ESM.


### PR DESCRIPTION
**[URL to the resource here.]**

**[Explain what this resource is all about and why it should be included here.]**
