### PR TITLE
Add graphql-to-karate to Testing Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ If you want to contribute to this list (please do), send me a pull request.
 ### Tools - Testing
 
 - [Step CI](https://stepci.com) - Open-Source API Testing and Monitoring with GraphQL support
+- [graphql-to-karate](https://github.com/wbaldoumas/graphql-to-karate) - Generate Karate API tests from your GraphQL schemas
 
 <a name="tool-security" />
 


### PR DESCRIPTION
[graphql-to-karate](https://github.com/wbaldoumas/graphql-to-karate) is a command line tool that automatically generates [Karate](https://github.com/karatelabs/karate) API tests from GraphQL schemas. It is highly configurable, usable in both interactive and non-interactive mode, and supports most of the current GraphQL spec. 

See the demo [here](https://github.com/wbaldoumas/graphql-to-karate#-demonstration).