### PR TITLE
Add Grafbase

### DIFF
--- a/README.md
+++ b/README.md
@@ -761,6 +761,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Nhost](https://nhost.io/) - Open source Firebase alternative with GraphQL
 - [Saleor](https://github.com/mirumee/saleor/) - GraphQL-first headless e-commerce platform.
 - [Stargate](https://stargate.io/docs/latest/quickstart/qs-graphql-cql-first.html) - Open source data gateway currently supporting Apache Cassandra&reg; and DataStax Enterprise.
+- [Grafbase](https://grafbase.com) - Instant GraphQL APIs for any data source.
 
 ### CDN
 


### PR DESCRIPTION
[https://grafbase.com](https://grafbase.com)

Allows users to merge multiple GraphQL and OpenAPIs together as well as extend APIs with resolvers, add caching, auth and more. Works locally too!
