### PR TITLE
add graphql cop to the security tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,6 +692,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [GraphQL Raider](https://portswigger.net/bappstore/4841f0d78a554ca381c65b26d48207e6) [BurpSuite](https://portswigger.net/burp)
 - [WAF for graphQL](https://lab.wallarm.com/api-security-solution/) - Web Application Firewall for graphQL APIs
 - [GraphQL Intruder](https://github.com/davinerd/gql_intruder) - Plugin based python script to perform GraphQL vulnerability assessment.
+- [GraphQL Cop](https://github.com/dolevf/graphql-cop) - Security Audit Utility for GraphQL
 
 ### Tools - Browser Extensions
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/dolevf/graphql-cop

**[Explain what this resource is all about and why it should be included here.]**
Seems to be a simple tool to run some security checks on CI and has ~300k stars on github atm.