### PR TITLE
add load-gql ad miscellaneous tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ If you want to contribute to this list (please do), send me a pull request.
 
 - [graphql-tools](https://github.com/apollographql/graphql-tools) - Tool library for building and maintaining GraphQL-JS servers.
 - [graphql-tag](https://github.com/apollographql/graphql-tag) - A JavaScript template literal tag that parses GraphQL queries.
+- [load-gql](https://github.com/KunalSin9h/load-gql) - A tiny, zero dependency GraphQL schema loader from files and folders.
 - [graphql-compose](https://github.com/graphql-compose/graphql-compose) - Tool which allows you to construct flexible graphql schema from different data sources via plugins.
 - [graphql-modules](https://github.com/Urigo/graphql-modules) - Separate GraphQL server into smaller, reusable parts by modules or features.
 - [graphql-shield](https://github.com/maticzav/graphql-shield) - A library that helps creating a permission layer for a graphql api.


### PR DESCRIPTION
https://github.com/KunalSin9h/load-gql

This is a GraphQL schema loader from files and folder, with simple API, it is tiny and have no dependencies. This helps in aggregating all the graphql schemas from files with .graphql / .gql extension and can traverse folder recursively to get schema.  
