### PR TITLE
docs: add `Tailcall`

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,12 +620,14 @@ If you want to contribute to this list (please do), send me a pull request.
 - [juniper](https://github.com/graphql-rust/juniper) - GraphQL server library for Rust.
 - [graphql-client](https://github.com/tomhoule/graphql-client) - GraphQL client library for Rust with WebAssembly (wasm) support.
 - [graphql-parser](https://github.com/graphql-rust/graphql-parser) - A parser, formatter and AST for the GraphQL query and schema definition language for Rust.
+- [tailcall](https://github.com/tailcallhq/tailcall) - A platform for building high-performance GraphQL backends.
 
 <a name="rust-example" />
 
 #### Rust Examples
 
 - [Warp GraphQL Juniper](https://graphql-rust.github.io/)
+- [Tailcall](https://tailcall.run/docs/getting_started/configuration)
 
 <a name="d" />
 


### PR DESCRIPTION
https://github.com/tailcallhq/tailcall

Tailcall is a High Performance no code GraphQL solution build on Rust. Independent Benchmarks could be found [here](https://github.com/graphql-crystal/benchmarks). It can be used at various places in your API infrastructure on Edge, Gateway and on service layers
