### PR TITLE
Add `graphql-sunset`

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Validator.js Wrapper Directive](https://github.com/ktutnik/graphql-directive/tree/master/packages/validator) - A comprehensive list of validator directive wraps Validator.js functionalities
 - [WunderGraph Cosmo](https://github.com/wundergraph/cosmo) - The Open-Source GraphQL Federation Solution with Full Lifecycle API Management for (Federated) GraphQL. Schema Registry, composition checks, analytics, metrics, tracing and routing.
 - [graphql-go-tools](https://github.com/wundergraph/graphql-go-tools) - A graphQL Router / API Gateway framework written in Golang, focussing on correctness, extensibility, and high-performance. Supports Federation v1 & v2, Subscriptions & more.
+- [graphql-sunset](https://github.com/sophiabits/graphql-sunset) - Quickly and easily add support for the `Sunset` header to your GraphQL server, to better communicate upcoming breaking changes.
 
 <a name="js-example" />
 
@@ -684,7 +685,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Brangr](https://github.com/networkimprov/brangr) - A unique, user-friendly data browser/viewer for any GraphQL service, with attractive result layouts.
 - [Insomnia](https://insomnia.rest/) - A full-featured API client with first-party GraphQL query editor.
 - [Postman](https://learning.postman.com/docs/sending-requests/supported-api-frameworks/graphql/) - An HTTP Client that supports editing GraphQL queries.
-- [Bruno](https://github.com/usebruno/bruno) - Fast, open source API client, which stores collections offline-only in a Git-friendly plain text markup language. 
+- [Bruno](https://github.com/usebruno/bruno) - Fast, open source API client, which stores collections offline-only in a Git-friendly plain text markup language.
 - [Escape GraphMan](https://github.com/Escape-Technologies/graphman) - Generate a complete Postman collection from a GraphQL endpoint.
 - [Apollo Sandbox](https://sandbox.apollo.dev/) - The quickest way to navigate and test your GraphQL endpoints.
 - [GraphQL Birdseye](https://github.com/Novvum/graphql-birdseye) – View any GraphQL schema as a dynamic and interactive graph.
@@ -873,7 +874,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Securing GraphQL API](https://lab.wallarm.com/securing-graphql-api/)
 - [Security Points to Consider Before Implementing GraphQL](https://nordicapis.com/security-points-to-consider-before-implementing-graphql/)
 - [GraphQL for Pentesters](https://www.acceis.fr/graphql-for-pentesters/) - Introduction to Basic Concepts, Security Considerations & Reconnaissance, Vulnerabilities and Attacks, Offensive Tools.
-- [Authorization Patterns in GraphQL](https://www.osohq.com/post/graphql-authorization) 
+- [Authorization Patterns in GraphQL](https://www.osohq.com/post/graphql-authorization)
 
 <a name="post" />
 


### PR DESCRIPTION
**[URL to the resource here.]**
https://github.com/sophiabits/graphql-sunset

**[Explain what this resource is all about and why it should be included here.]**
`Sunset` is a standard HTTP header used to communicate that a resource will become unavailable in future. This signaling is important as it gives consumers warning for them to move off the deprecated resource before removal, and because the `Sunset` header is interpretable programmatically consumers can build nice alerting systems around it (WeWork has done this, for instance: https://github.com/wework/faraday-sunset)

This library offers a simple and easy way to add support for this header to GraphQL servers. Schema resources can be annotated with an `@sunset` directive, and the server will automatically send back a `Sunset` response header to any consumer that requests those marked resources.