### PR TITLE
Add gqlhash

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,6 @@ If you want to contribute to this list (please do), send me a pull request.
 - [WunderGraph Cosmo](https://github.com/wundergraph/cosmo) - The Open-Source GraphQL Federation Solution with Full Lifecycle API Management for (Federated) GraphQL. Schema Registry, composition checks, analytics, metrics, tracing and routing.
 - [graphql-go-tools](https://github.com/wundergraph/graphql-go-tools) - A graphQL Router / API Gateway framework written in Golang, focussing on correctness, extensibility, and high-performance. Supports Federation v1 & v2, Subscriptions & more.
 - [graphql-sunset](https://github.com/sophiabits/graphql-sunset) - Quickly and easily add support for the `Sunset` header to your GraphQL server, to better communicate upcoming breaking changes.
-- [gqlhash](https://github.com/romshark/gqlhash) - Lightning fast GraphQL query hasher that ignores formatting diffs and comments and supports multiple hashing functions.
 
 <a name="js-example" />
 
@@ -766,6 +765,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [ILLA Cloud](https://www.illacloud.com/) – Open-source low-code tool building platform provides an easy way to integrate with GraphQL with minimal configurations
 - [DronaHQ](https://www.dronahq.com/) - Build internal tools, dashboards, admin panel on top of GraphQL data in minutes
 - [Dynaboard](https://dynaboard.com) - Generate low-code web apps from any GraphQL API using AI.
+- [gqlhash](https://github.com/romshark/gqlhash) - Lightning fast query hasher that ignores formatting diffs and comments and supports multiple hashing functions.
   <a name="databases" />
 
 ## Databases

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [WunderGraph Cosmo](https://github.com/wundergraph/cosmo) - The Open-Source GraphQL Federation Solution with Full Lifecycle API Management for (Federated) GraphQL. Schema Registry, composition checks, analytics, metrics, tracing and routing.
 - [graphql-go-tools](https://github.com/wundergraph/graphql-go-tools) - A graphQL Router / API Gateway framework written in Golang, focussing on correctness, extensibility, and high-performance. Supports Federation v1 & v2, Subscriptions & more.
 - [graphql-sunset](https://github.com/sophiabits/graphql-sunset) - Quickly and easily add support for the `Sunset` header to your GraphQL server, to better communicate upcoming breaking changes.
+- [gqlhash](https://github.com/romshark/gqlhash) - Lightning fast GraphQL query hasher that ignores formatting diffs and comments and supports multiple hashing functions.
 
 <a name="js-example" />
 


### PR DESCRIPTION
https://github.com/romshark/gqlhash

I built this tool because we wanted to implement an efficient allowlist for GraphQL queries
by SHA1 hash.
The original queries our clients provide aren't always formatted properly, hence
a single *format on save* or *missing whitespace somewhere* could change the hash of
a query in the allowlist, which made it quite fragile.
I also wanted comments to be ignored and not affect the generated hash.

gqlhash hashes executable documents very efficiently with a variaty of hash functions.
MIT Licence, fully open source.