### PR TITLE
Added PHP library jerowork/graphql-schema-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [siler](https://github.com/leocavalcante/siler) - Plain-old functions providing a declarative API for GraphQL servers with Subscriptions support.
 - [graphql-request-builder](https://github.com/dpauli/php-graphql-request-builder) - Builds request payload in GraphQL structure.
 - [drupal/graphql](https://www.drupal.org/project/graphql) - Craft and expose a GraphQL schema for Drupal 9 and 10.
+- [jerowork/graphql-schema-builder](https://github.com/jerowork/graphql-attribute-schema) - Easily build your GraphQL schema for webonyx/graphql-php using PHP attributes instead of large configuration arrays.
 
 <a name="php-example" />
 


### PR DESCRIPTION
# Description
Added PHP library **jerowork/graphql-schema-builder**.
"Easily build your GraphQL schema for webonyx/graphql-php using PHP attributes instead of large configuration arrays."

A newly introduced library for the latest PHP versions (^8.3), making use of attributes :).

URL: https://github.com/jerowork/graphql-attribute-schema
(docs: https://jerowork.github.io/graphql-attribute-schema)