### PR TITLE
Added link to Apollo Persisted Query debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,6 +769,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [DronaHQ](https://www.dronahq.com/) - Build internal tools, dashboards, admin panel on top of GraphQL data in minutes
 - [Dynaboard](https://dynaboard.com) - Generate low-code web apps from any GraphQL API using AI.
 - [gqlhash](https://github.com/romshark/gqlhash) - Lightning fast query hasher that ignores formatting diffs and comments and supports multiple hashing functions.
+- [Apollo APQ Debugger](https://github.com/rookieInTraining/apq-debugger) - Reveal full GraphQL queries behind Apollo APQ hashes. Inspect fallback flow and debug Automatic Persisted Queries in DevTools.
   <a name="databases" />
 
 ## Databases


### PR DESCRIPTION
Added link to Apollo Persisted Query debugger, an extension to reveal the payloads behind APQ queries

[**Chrome Extension Link**](https://chromewebstore.google.com/detail/apq-debugger-beta/gbanmonipiommdljkadhhiomhkgjchee?authuser=0&hl=en)

**A Chrome extension for debugging Apollo GraphQL Automatic Persisted Queries (APQ).
When Apollo Client uses APQ, the first request sends only a SHA-256 hash of the query, hiding the full GraphQL operation from network inspectors. This extension intercepts those requests and forces a fallback, revealing the complete query in Chrome DevTools. It’s invaluable for developers troubleshooting APQ issues, verifying hash–query matches, or inspecting whitelisted queries during development. By making persisted query behavior visible, it shortens debugging time and improves confidence in GraphQL API integrations.**
