### PR TITLE
Add xyd.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -739,6 +739,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [gqldoc](https://github.com/Code-Hex/gqldoc) - The easiest way to make API documents for GraphQL.
 - [spectaql](https://github.com/anvilco/spectaql) - Autogenerate static GraphQL API documentation.
 - [graphql-markdown](https://graphql-markdown.github.io/) - Flexible documentation for GraphQL powered with Docusaurus.
+- [xyd](https://xyd.dev) - Generate GraphQL API docs.
 
 ### Tools - Editor Plugins
 


### PR DESCRIPTION
https://xyd.dev

Docs Framework that is able to generate GraphQL API docs.

GraphQL Guide: [xyd.dev/docs/guides/graphql](https://xyd.dev/docs/guides/graphql)
Demo: [examples.graphql.xyd.dev](https://examples.graphql.xyd.dev)