### PR TITLE
Merge  "Tools - Testing" & "Tools - Prototyping" and update this subheading

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,12 +704,15 @@ If you want to contribute to this list (please do), send me a pull request.
 
 <a name="tool-testing" />
 
-### Tools - Testing
+### Tools - Testing, Prototyping & Mocking
 
-- [Step CI](https://stepci.com) - Open-Source API Testing and Monitoring with GraphQL support
-- [graphql-to-karate](https://github.com/wbaldoumas/graphql-to-karate) - Generate Karate API tests from your GraphQL schemas
-- [Microcks](https://microcks.io/) - The open source ([CNCF](https://www.cncf.io/projects/microcks/) project), cloud native tool for API Mocking and Testing with [GraphQL support](https://microcks.io/blog/graphql-features-what-to-expect/) 🎥 [GraphQL conf 2023](https://youtu.be/UjDnrrTp7uI?si=M6S4l_Bukp9CEYl4)
-- [Keploy](https://keploy.io/) - Open-source AI Powered API testing tool that generates test cases and data mocks automatically by recording real API traffic. Supports GraphQL, REST, and gRPC.
+- [Beeceptor](https://beeceptor.com/graphql-mock-server/) - A no-code platform for creating AI-powered **GraphQL Mock Servers** from your schema (SDL) with rules, stateful mocking, mutation/subscription, to speed up development and integration testing.
+- [graphql-to-karate](https://github.com/wbaldoumas/graphql-to-karate) - **Generate Karate API tests** from your GraphQL schemas
+- [GraphQL Faker](https://github.com/APIs-guru/graphql-faker) - 🎲 Mock or extend your GraphQL API with faked data. No coding required.
+- [GraphQL Inspector](https://the-guild.dev/graphql/inspector) - A tool to **validate schemas**, compare schema changes, find breaking changes, and check document coverage against a schema.
+- [Microcks](https://microcks.io/) - The open source ([CNCF](https://www.cncf.io/projects/microcks/) project), cloud native tool for **API Mocking** and Testing with [GraphQL support](https://microcks.io/blog/graphql-features-what-to-expect/) 🎥 [GraphQL conf 2023](https://youtu.be/UjDnrrTp7uI?si=M6S4l_Bukp9CEYl4)
+- [Keploy](https://keploy.io/) - Open-source AI Powered API testing tool that generates test cases and **data mocks automatically by recording real API traffic**. Supports GraphQL, REST, and gRPC.
+- [Step CI](https://stepci.com) - Open-Source API **Testing and Monitoring** with GraphQL support
 
 <a name="tool-security" />
 
@@ -730,10 +733,6 @@ If you want to contribute to this list (please do), send me a pull request.
 
 - [Apollo Client Developer Tools](https://github.com/apollographql/apollo-client-devtools) - GraphQL debugging tools for Apollo Client in the Chrome developer console
 - [GraphQL Network Inspector](https://chrome.google.com/webstore/detail/graphql-network-inspector/ndlbedplllcgconngcnfmkadhokfaaln) - A simple and clean chrome dev-tools extension for GraphQL network inspection.
-
-### Tools - Prototyping
-
-- [GraphQL Faker](https://github.com/APIs-guru/graphql-faker) - 🎲 Mock or extend your GraphQL API with faked data. No coding required.
 
 ### Tools - Docs
 


### PR DESCRIPTION
Pull request to:
1) Add new tools (Guild's Graph Inspector and Beeceptor), and
2) Improve the organization of GraphQL tools by having a more specific section for testing, prototyping and mocking (by relocating relevant existing tools into a singular section). This change centralizes resources for developers in a section specifically focused on API prototyping, mocking, and testing. The reason for doing this is because testing, mocking and prototyping, inherently share some links with each other.

Changes made:
- Renamed  `Tools - Testing` to `Tools - Testing, Prototyping & Mocking`.
- Removed `Tools - Prototyping` and merged the contents of this section to `Tools - Testing, Prototyping & Mocking` category
- Added [guild.dev's](https://the-guild.dev/) GraphQL inspector to this category.
- Added Beeceptor to this list.
- Moved the already existing tools into this category for easier discoverability
- Organized the list in ascending order
- Added markdown emphasis to the one-liner texts