### PR TITLE
Add Vedika - Astrology GraphQL API service

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Nhost](https://nhost.io/) - Open source Firebase alternative with GraphQL
 - [Saleor](https://github.com/mirumee/saleor/) - GraphQL-first headless e-commerce platform.
 - [Stargate](https://stargate.io/docs/latest/quickstart/qs-graphql-cql-first.html) - Open source data gateway currently supporting Apache Cassandra&reg; and DataStax Enterprise.
+- [Vedika](https://vedika.io) - Vedic astrology AI API with GraphQL support for horoscopes, birth charts, kundali matching, and 108+ endpoints.
 - [Grafbase](https://grafbase.com) - Instant GraphQL APIs for any data source.
 
 ### CDN


### PR DESCRIPTION
## Summary

Adding [Vedika](https://vedika.io) to the Services section.

**Vedika** is an AI-powered Vedic astrology API with full GraphQL support:
- **GraphQL Endpoint**: Complete query, mutation, and subscription support
- **108+ Endpoints**: Comprehensive astrology calculations
- **22 Languages**: Multilingual responses
- **AI Chat**: Integrated AI astrology assistant

### GraphQL Features:
- GraphQL schema with typed queries and mutations
- Subscription support for real-time updates
- GraphQL playground available
- Compatible with Apollo Client, Relay, and other GraphQL clients

This fits well in the "Services" section alongside other GraphQL API services.