### PR TITLE
Add Vedika API

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,6 +793,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Nhost](https://nhost.io/) - Open source Firebase alternative with GraphQL
 - [Saleor](https://github.com/mirumee/saleor/) - GraphQL-first headless e-commerce platform.
 - [Stargate](https://stargate.io/docs/latest/quickstart/qs-graphql-cql-first.html) - Open source data gateway currently supporting Apache Cassandra&reg; and DataStax Enterprise.
+- [Vedika](https://vedika.io) - Vedic astrology API with GraphQL support, providing 108+ endpoints for birth charts, horoscopes, panchang, dasha, compatibility, and AI-powered chatbot in 22 languages.
 - [Grafbase](https://grafbase.com) - Instant GraphQL APIs for any data source.
 
 ### CDN


### PR DESCRIPTION
Adds Vedika (https://vedika.io) - Vedic astrology API with GraphQL support, providing 108+ endpoints for birth charts, horoscopes, panchang, dasha, compatibility, and AI-powered chatbot in 22 languages.