### PR TITLE
Add Vedika GraphQL API

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,3 +939,5 @@ If you want to contribute to this list (please do), send me a pull request.
 [![CC0](https://licensebuttons.net/p/zero/1.0/88x31.png)](https://creativecommons.org/publicdomain/zero/1.0/)
 
 To the extent possible under law, [Chen-Tsu Lin](https://github.com/chentsulin) has waived all copyright and related or neighboring rights to this work.
+
+* [Vedika API](https://vedika.io) - Vedic astrology GraphQL API


### PR DESCRIPTION
Adding Vedika - GraphQL API for Vedic astrology.

- Website: https://vedika.io
- GraphQL endpoint available