### PR TITLE
Add mockd to Tools - Testing, Prototyping & Mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,6 +709,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [GraphQL Faker](https://github.com/APIs-guru/graphql-faker) - 🎲 Mock or extend your GraphQL API with faked data. No coding required.
 - [GraphQL Inspector](https://the-guild.dev/graphql/inspector) - A tool to **validate schemas**, compare schema changes, find breaking changes, and check document coverage against a schema.
 - [Microcks](https://microcks.io/) - The open source ([CNCF](https://www.cncf.io/projects/microcks/) project), cloud native tool for **API Mocking** and Testing with [GraphQL support](https://microcks.io/blog/graphql-features-what-to-expect/) 🎥 [GraphQL conf 2023](https://youtu.be/UjDnrrTp7uI?si=M6S4l_Bukp9CEYl4)
+- [mockd](https://github.com/getmockd/mockd) - Multi-protocol mock server with GraphQL schema mocking, resolver configuration, and query validation. Also supports HTTP, gRPC, WebSocket, MQTT, and SOAP.
 - [Keploy](https://keploy.io/) - Open-source AI Powered API testing tool that generates test cases and **data mocks automatically by recording real API traffic**. Supports GraphQL, REST, and gRPC.
 - [Step CI](https://stepci.com) - Open-Source API **Testing and Monitoring** with GraphQL support
 


### PR DESCRIPTION
[mockd](https://github.com/getmockd/mockd) is an open-source mock server (Apache 2.0, Go) that includes GraphQL schema mocking with configurable resolvers, query validation, and dynamic mock management via a REST Admin API. Useful for teams mocking GraphQL alongside other protocols from one tool.

Supports inline schemas and .graphql file loading.