### PR TITLE
Add Schemato to GraphQL tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [WunderGraph Cosmo](https://github.com/wundergraph/cosmo) - The Open-Source GraphQL Federation Solution with Full Lifecycle API Management for (Federated) GraphQL. Schema Registry, composition checks, analytics, metrics, tracing and routing.
 - [graphql-go-tools](https://github.com/wundergraph/graphql-go-tools) - A graphQL Router / API Gateway framework written in Golang, focussing on correctness, extensibility, and high-performance. Supports Federation v1 & v2, Subscriptions & more.
 - [graphql-sunset](https://github.com/sophiabits/graphql-sunset) - Quickly and easily add support for the `Sunset` header to your GraphQL server, to better communicate upcoming breaking changes.
+- [Schemato](https://www.schemato.top/graphql-to-typescript) - Browser-only GraphQL SDL converter for generating TypeScript, Zod, Pydantic, Go, Rust, and other typed models.
 
 <a name="js-example" />
 


### PR DESCRIPTION
Adds Schemato to the Tools / Miscellaneous section.

It is a browser-only GraphQL SDL converter that can generate typed models for TypeScript, Zod, Pydantic, Go, Rust, Swift, Kotlin, Java, C#, Dart, PHP, Ruby, Yup, Joi, and Python dataclasses.

GraphQL-specific entry point:
https://www.schemato.top/graphql-to-typescript

Disclosure: I'm the maintainer.

**[URL to the resource here.]**

**[Explain what this resource is all about and why it should be included here.]**
