### PR TITLE
Add hasura-security to Tools - Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [GraphQL Cop](https://github.com/dolevf/graphql-cop) - Security Audit Utility for GraphQL
 - [GraphQLer](https://github.com/omar2535/GraphQLer) - Dependency-aware dynamic GraphQL testing tool
 - [Vulert](https://vulert.com) - Vulert secures software by detecting vulnerabilities in open-source dependencies—without accessing your code. It supports Js, PHP, Java, Python, and more
+- [hasura-security](https://github.com/Perufitlife/hasura-security) - Active-probe security auditor for self-hosted Hasura GraphQL Engine: detects open introspection, public-role data leaks and unauthenticated endpoints
 
 ### Tools - Browser Extensions
 


### PR DESCRIPTION
Adds **hasura-security** to the `Tools - Security` category.

It is an open-source (MIT), active-probe security auditor for self-hosted **Hasura GraphQL Engine**: it flags open introspection, public-role data leaks, and unauthenticated GraphQL endpoints — fitting alongside the other GraphQL security scanners already listed in this section.

- Repo: https://github.com/Perufitlife/hasura-security

Disclosure: I am the author of this tool. Added to the bottom of the category per the contribution guidelines; one entry, one PR.