### PR TITLE
Add zodql to JavaScript/TypeScript clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [aws-amplify](https://github.com/aws-amplify/amplify-js) - A client library developed by Amazon for caching, analytics and more that includes a way to fetch GraphQL queries.
 - [gqty](https://github.com/gqty-dev/gqty) - A No GraphQL client for TypeScript
 - [genql](https://github.com/remorses/genql) - Type safe TypeScript client for any GraphQL API.
+- [zodql](https://github.com/mattiasahlsen/zodql) - Type-safe GraphQL client that uses Zod schemas as the single source of truth to build queries, infer response types, and validate responses at runtime.
 
 ##### Frontend Framework Integrations
 


### PR DESCRIPTION
**[zodql](https://github.com/mattiasahlsen/zodql)**

zodql is a type-safe GraphQL client for TypeScript that uses [Zod](https://github.com/colinhacks/zod) schemas as the single source of truth. From one schema it builds the GraphQL query string, infers the response's TypeScript types, and validates the response at runtime — eliminating duplicate query strings, type definitions, and code generation steps. It's transport-agnostic and supports variables, aliases, fragments, unions, and interfaces.

Added to the bottom of the **Implementations → JavaScript/TypeScript → Clients** category, per the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)