### PR TITLE
Add Codex to Services

### DIFF
--- a/README.md
+++ b/README.md
@@ -797,6 +797,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [Stargate](https://stargate.io/docs/latest/quickstart/qs-graphql-cql-first.html) - Open source data gateway currently supporting Apache Cassandra&reg; and DataStax Enterprise.
 - [Vedika](https://vedika.io) - Vedic astrology AI API with GraphQL support for horoscopes, birth charts, kundali matching, and 108+ endpoints.
 - [Grafbase](https://grafbase.com) - Instant GraphQL APIs for any data source.
+- [Codex](https://www.codex.io) - GraphQL API for real-time and historical on-chain data, including token prices, charts, and holders across 90+ networks.
 
 ### CDN
 


### PR DESCRIPTION
Adds [Codex](https://www.codex.io) to the Services section — a GraphQL API for real-time and historical on-chain data (token prices, charts, holders, and market data) across 90+ networks.