### PR TITLE
Add GalleonQL to Tools - Editors & IDEs & Explorers

### DIFF
--- a/README.md
+++ b/README.md
@@ -700,6 +700,7 @@ If you want to contribute to this list (please do), send me a pull request.
 - [gqt](https://github.com/eerimoq/gqt) - Build and execute GraphQL queries in the terminal.
 - [Hackolade](https://studio.hackolade.com/) - Visual GraphQL schema editor to generate Schema Definition Language files without any knowledge of the GraphQL syntax. Also visualize and document existing endpoints with introspection.  Additional info and instructions [here](https://hackolade.com/help/GraphQL.html)
 - [Smart Formatter - GraphQL Query Formatter](https://smartformatter.com/tools/graphql-query-formatter) - A client-side, browser-only tool to format, beautify, and validate GraphQL queries and schemas instantly.
+- [GalleonQL](https://galleonql.com/) - A desktop API client built specifically for GraphQL (macOS, Windows, Linux), pairing an introspected schema browser with an incremental query builder and switchable endpoint profiles.
 
 
 <a name="tool-testing" />


### PR DESCRIPTION
**https://galleonql.com/**

**GalleonQL is a desktop API client built specifically for GraphQL, available for macOS, Windows and Linux.
It fetches a schema by HTTP introspection and shows it as reference documentation next to an incremental
query builder, so you insert a root field and then expand it one level at a time. Requests are issued from
its native backend rather than a browser, so CORS restrictions do not apply, and saved connection profiles
let you switch endpoints without duplicating queries.**

Disclosure: I am the author of GalleonQL.
